### PR TITLE
WIP: split up and reshuffle hook calling

### DIFF
--- a/src/pluggy/__init__.py
+++ b/src/pluggy/__init__.py
@@ -14,5 +14,5 @@ __all__ = [
 ]
 
 from ._manager import PluginManager, PluginValidationError
-from ._callers import HookCallError
+from ._exceptions import HookCallError
 from ._hooks import HookspecMarker, HookimplMarker

--- a/src/pluggy/_exceptions.py
+++ b/src/pluggy/_exceptions.py
@@ -1,0 +1,2 @@
+class HookCallError(Exception):
+    """Hook was called wrongly."""

--- a/testing/benchmark.py
+++ b/testing/benchmark.py
@@ -34,13 +34,17 @@ def wrappers(request):
 def test_hook_and_wrappers_speed(benchmark, hooks, wrappers):
     def setup():
         hook_name = "foo"
-        hook_impls = []
-        for method in hooks + wrappers:
+        wrapping = []
+        nonwrappers = []
+        for method in hooks:
             f = HookImpl(None, "<temp>", method, method.example_impl)
-            hook_impls.append(f)
+            nonwrappers.append(f)
+        for method in wrappers:
+            f = HookImpl(None, "<temp>", method, method.example_impl)
+            wrapping.append(f)
         caller_kwargs = {"arg1": 1, "arg2": 2, "arg3": 3}
         firstresult = False
-        return (hook_name, hook_impls, caller_kwargs, firstresult), {}
+        return (hook_name, wrapping, nonwrappers, caller_kwargs, firstresult), {}
 
     benchmark.pedantic(_multicall, setup=setup)
 

--- a/testing/test_multicall.py
+++ b/testing/test_multicall.py
@@ -11,10 +11,15 @@ hookimpl = HookimplMarker("example")
 def MC(methods, kwargs, firstresult=False):
     caller = _multicall
     hookfuncs = []
+    hookwrappers = []
+
     for method in methods:
         f = HookImpl(None, "<temp>", method, method.example_impl)
-        hookfuncs.append(f)
-    return caller("foo", hookfuncs, kwargs, firstresult)
+        if f.hookwrapper:
+            hookwrappers.append(f)
+        else:
+            hookfuncs.append(f)
+    return caller("foo", hookwrappers, hookfuncs, kwargs, firstresult)
 
 
 def test_keyword_args():


### PR DESCRIPTION
the goal is to have wrappers and non-wrappers be split into separate lists as well as changing historic hooks

ong term experiment

## Summary by Sourcery

Split hook execution into separate wrapper and non-wrapper flows, introduce a unified Result type for hook outcomes, and refactor HookImpl for cleaner argument handling.

Enhancements:
- Refactor hook execution (_multicall and manager._hookexec) to accept distinct wrapper and non-wrapper lists
- Introduce a DEFAULTS mapping and normalize_hookimpl_opts returning a new options dict
- Implement a final Result class replacing internal _Result for unified result and exception management
- Enhance HookImpl with __slots__, custom __getattr__, optimized argument getters, and wrapper support in __call__
- Move HookCallError into a dedicated exceptions module for clearer error handling
- Add type annotations across the plugin manager and DistFacade for improved type safety

Tests:
- Update test_multicall and benchmark setup to use separate wrapper and non-wrapper argument signatures in _multicall