### PR TITLE
feat(config): replace TypedDict options with Hook*Configuration

### DIFF
--- a/changelog/704.removal.rst
+++ b/changelog/704.removal.rst
@@ -1,0 +1,8 @@
+Hook options are now :class:`pluggy.HookspecConfiguration` /
+:class:`pluggy.HookimplConfiguration` objects (markers attach these instead of
+dicts). ``PluginManager.parse_hookimpl_opts`` /
+``parse_hookspec_opts`` remain as a deprecated pytest/support concession that
+returns legacy dicts and are only invoked during registration when a subclass
+overrides them and no modern configuration attribute was found.
+``HookspecOpts`` / ``HookimplOpts`` TypedDicts remain importable for
+pytest/typing compatibility.

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -40,12 +40,10 @@ API Reference
 .. autoclass:: pluggy.HookImpl()
     :members:
 
-.. autoclass:: pluggy.HookspecOpts()
-    :show-inheritance:
+.. autoclass:: pluggy.HookspecConfiguration()
     :members:
 
-.. autoclass:: pluggy.HookimplOpts()
-    :show-inheritance:
+.. autoclass:: pluggy.HookimplConfiguration()
     :members:
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -767,10 +767,13 @@ and particular plugins in it:
 
 Parsing mark options
 ^^^^^^^^^^^^^^^^^^^^
-You can retrieve the *options* applied to a particular
-*hookspec* or *hookimpl* as per :ref:`marking_hooks` using the
+Markers attach :class:`~pluggy.HookspecConfiguration` /
+:class:`~pluggy.HookimplConfiguration` objects to functions. The
 :py:meth:`~pluggy.PluginManager.parse_hookspec_opts()` and
-:py:meth:`~pluggy.PluginManager.parse_hookimpl_opts()` respectively.
+:py:meth:`~pluggy.PluginManager.parse_hookimpl_opts()` methods remain as a
+**deprecated** pytest/support concession that returns legacy dict-shaped
+options; registration only calls them when a subclass overrides them and no
+modern configuration attribute was found.
 
 
 .. _calling:

--- a/src/pluggy/__init__.py
+++ b/src/pluggy/__init__.py
@@ -3,8 +3,10 @@ __all__ = [
     "HookCaller",
     "HookImpl",
     "HookRelay",
+    "HookimplConfiguration",
     "HookimplMarker",
     "HookimplOpts",
+    "HookspecConfiguration",
     "HookspecMarker",
     "HookspecOpts",
     "PluggyTeardownRaisedWarning",
@@ -14,15 +16,17 @@ __all__ = [
     "Result",
     "__version__",
 ]
+from ._config import HookimplConfiguration
+from ._config import HookspecConfiguration
 from ._hooks import HookCaller
 from ._hooks import HookImpl
 from ._hooks import HookimplMarker
-from ._hooks import HookimplOpts
 from ._hooks import HookRelay
 from ._hooks import HookspecMarker
-from ._hooks import HookspecOpts
 from ._manager import PluginManager
 from ._manager import PluginValidationError
+from ._pytest_compat import HookimplOpts
+from ._pytest_compat import HookspecOpts
 from ._result import HookCallError
 from ._result import Result
 from ._warnings import PluggyTeardownRaisedWarning

--- a/src/pluggy/_caller.py
+++ b/src/pluggy/_caller.py
@@ -15,8 +15,8 @@ from typing import TYPE_CHECKING
 from typing import TypeAlias
 import warnings
 
-from ._config import HookimplOpts
-from ._config import HookspecOpts
+from ._config import HookimplConfiguration
+from ._config import HookspecConfiguration
 from ._decorators import _Namespace
 from ._decorators import HookSpec
 from ._implementation import _Plugin
@@ -69,7 +69,7 @@ class HookCaller:
         name: str,
         hook_execute: _HookExec,
         specmodule_or_class: _Namespace | None = None,
-        spec_opts: HookspecOpts | None = None,
+        spec_opts: HookspecConfiguration | None = None,
     ) -> None:
         """:meta private:"""
         #: Name of the hook getting called.
@@ -98,7 +98,7 @@ class HookCaller:
     def set_specification(
         self,
         specmodule_or_class: _Namespace,
-        spec_opts: HookspecOpts,
+        spec_opts: HookspecConfiguration,
     ) -> None:
         if self.spec is not None:
             raise ValueError(
@@ -106,7 +106,7 @@ class HookCaller:
                 f"within namespace {self.spec.namespace}"
             )
         self.spec = HookSpec(specmodule_or_class, self.name, spec_opts)
-        if spec_opts.get("historic"):
+        if spec_opts.historic:
             self._call_history = []
 
     def is_historic(self) -> bool:
@@ -183,7 +183,7 @@ class HookCaller:
             "Cannot directly call a historic hook - use call_historic instead."
         )
         self._verify_all_args_are_provided(kwargs)
-        firstresult = self.spec.opts.get("firstresult", False) if self.spec else False
+        firstresult = self.spec.opts.firstresult if self.spec else False
         # Copy because plugins may register other plugins during iteration (#438).
         return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
 
@@ -224,14 +224,7 @@ class HookCaller:
             "Cannot directly call a historic hook - use call_historic instead."
         )
         self._verify_all_args_are_provided(kwargs)
-        opts: HookimplOpts = {
-            "wrapper": False,
-            "hookwrapper": False,
-            "optionalhook": False,
-            "trylast": False,
-            "tryfirst": False,
-            "specname": None,
-        }
+        opts = HookimplConfiguration()
         hookimpls = self._hookimpls.copy()
         for method in methods:
             hookimpl = HookImpl(None, "<temp>", method, opts)
@@ -245,7 +238,7 @@ class HookCaller:
             ):
                 i -= 1
             hookimpls.insert(i + 1, hookimpl)
-        firstresult = self.spec.opts.get("firstresult", False) if self.spec else False
+        firstresult = self.spec.opts.firstresult if self.spec else False
         return self._hookexec(self.name, hookimpls, kwargs, firstresult)
 
     def _maybe_apply_history(self, method: HookImpl) -> None:

--- a/src/pluggy/_config.py
+++ b/src/pluggy/_config.py
@@ -5,50 +5,163 @@ Configuration types for hook specifications and implementations.
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TypedDict
+from typing import Any
+from typing import Final
+from typing import final
 
 
-class HookspecOpts(TypedDict):
-    """Options for a hook specification."""
+@final
+class HookspecConfiguration:
+    """Configuration for a hook specification."""
 
-    #: Whether the hook is :ref:`first result only <firstresult>`.
-    firstresult: bool
-    #: Whether the hook is :ref:`historic <historic>`.
-    historic: bool
-    #: Whether the hook :ref:`warns when implemented <warn_on_impl>`.
-    warn_on_impl: Warning | None
-    #: Whether the hook warns when :ref:`certain arguments are requested
-    #: <warn_on_impl>`.
-    #:
-    #: .. versionadded:: 1.5
-    warn_on_impl_args: Mapping[str, Warning] | None
+    __slots__ = (
+        "firstresult",
+        "historic",
+        "warn_on_impl",
+        "warn_on_impl_args",
+    )
+    firstresult: Final[bool]
+    historic: Final[bool]
+    warn_on_impl: Final[Warning | None]
+    warn_on_impl_args: Final[Mapping[str, Warning] | None]
+
+    def __init__(
+        self,
+        firstresult: bool = False,
+        historic: bool = False,
+        warn_on_impl: Warning | None = None,
+        warn_on_impl_args: Mapping[str, Warning] | None = None,
+    ) -> None:
+        if historic and firstresult:
+            raise ValueError("cannot have a historic firstresult hook")
+        #: Whether the hook is :ref:`first result only <firstresult>`.
+        self.firstresult = firstresult
+        #: Whether the hook is :ref:`historic <historic>`.
+        self.historic = historic
+        #: Whether the hook :ref:`warns when implemented <warn_on_impl>`.
+        self.warn_on_impl = warn_on_impl
+        #: Whether the hook warns when :ref:`certain arguments are requested
+        #: <warn_on_impl>`.
+        self.warn_on_impl_args = warn_on_impl_args
+
+    def __repr__(self) -> str:
+        attrs = [
+            f"{slot}={getattr(self, slot)!r}"
+            for slot in self.__slots__
+            if getattr(self, slot)
+        ]
+        return f"HookspecConfiguration({', '.join(attrs)})"
 
 
-class HookimplOpts(TypedDict):
-    """Options for a hook implementation."""
+@final
+class HookimplConfiguration:
+    """Configuration for a hook implementation."""
 
-    #: Whether the hook implementation is a :ref:`wrapper <hookwrapper>`.
-    wrapper: bool
-    #: Whether the hook implementation is an :ref:`old-style wrapper
-    #: <old_style_hookwrappers>`.
-    hookwrapper: bool
-    #: Whether validation against a hook specification is :ref:`optional
-    #: <optionalhook>`.
-    optionalhook: bool
-    #: Whether to try to order this hook implementation :ref:`first
-    #: <callorder>`.
-    tryfirst: bool
-    #: Whether to try to order this hook implementation :ref:`last
-    #: <callorder>`.
-    trylast: bool
-    #: The name of the hook specification to match, see :ref:`specname`.
-    specname: str | None
+    __slots__ = (
+        "hookwrapper",
+        "optionalhook",
+        "specname",
+        "tryfirst",
+        "trylast",
+        "wrapper",
+    )
+    wrapper: Final[bool]
+    hookwrapper: Final[bool]
+    optionalhook: Final[bool]
+    tryfirst: Final[bool]
+    trylast: Final[bool]
+    specname: Final[str | None]
+
+    def __init__(
+        self,
+        wrapper: bool = False,
+        hookwrapper: bool = False,
+        optionalhook: bool = False,
+        tryfirst: bool = False,
+        trylast: bool = False,
+        specname: str | None = None,
+    ) -> None:
+        #: Whether the hook implementation is a :ref:`wrapper <hookwrapper>`.
+        self.wrapper = wrapper
+        #: Whether the hook implementation is an :ref:`old-style wrapper
+        #: <old_style_hookwrappers>`.
+        self.hookwrapper = hookwrapper
+        #: Whether validation against a hook specification is :ref:`optional
+        #: <optionalhook>`.
+        self.optionalhook = optionalhook
+        #: Whether to try to order this hook implementation :ref:`first
+        #: <callorder>`.
+        self.tryfirst = tryfirst
+        #: Whether to try to order this hook implementation :ref:`last
+        #: <callorder>`.
+        self.trylast = trylast
+        #: The name of the hook specification to match, see :ref:`specname`.
+        self.specname = specname
+
+    def __repr__(self) -> str:
+        attrs = [
+            f"{slot}={getattr(self, slot)!r}"
+            for slot in self.__slots__
+            if getattr(self, slot)
+        ]
+        return f"HookimplConfiguration({', '.join(attrs)})"
 
 
-def normalize_hookimpl_opts(opts: HookimplOpts) -> None:
-    opts.setdefault("tryfirst", False)
-    opts.setdefault("trylast", False)
-    opts.setdefault("wrapper", False)
-    opts.setdefault("hookwrapper", False)
-    opts.setdefault("optionalhook", False)
-    opts.setdefault("specname", None)
+def hookspec_config_from_mapping(
+    opts: Mapping[str, Any],
+) -> HookspecConfiguration:
+    """Build a :class:`HookspecConfiguration` from a mapping.
+
+    Intended for pytest/support migration only — not the public options API.
+    Prefer constructing :class:`HookspecConfiguration` directly.
+    """
+    return HookspecConfiguration(
+        firstresult=bool(opts.get("firstresult", False)),
+        historic=bool(opts.get("historic", False)),
+        warn_on_impl=opts.get("warn_on_impl"),
+        warn_on_impl_args=opts.get("warn_on_impl_args"),
+    )
+
+
+def hookimpl_config_from_mapping(
+    opts: Mapping[str, Any],
+) -> HookimplConfiguration:
+    """Build a :class:`HookimplConfiguration` from a mapping.
+
+    Intended for pytest/support migration only — not the public options API.
+    Prefer constructing :class:`HookimplConfiguration` directly.
+    """
+    return HookimplConfiguration(
+        wrapper=bool(opts.get("wrapper", False)),
+        hookwrapper=bool(opts.get("hookwrapper", False)),
+        optionalhook=bool(opts.get("optionalhook", False)),
+        tryfirst=bool(opts.get("tryfirst", False)),
+        trylast=bool(opts.get("trylast", False)),
+        specname=opts.get("specname"),
+    )
+
+
+def hookspec_config_to_mapping(
+    config: HookspecConfiguration,
+) -> dict[str, Any]:
+    """Serialize configuration to a legacy mapping (pytest/support only)."""
+    return {
+        "firstresult": config.firstresult,
+        "historic": config.historic,
+        "warn_on_impl": config.warn_on_impl,
+        "warn_on_impl_args": config.warn_on_impl_args,
+    }
+
+
+def hookimpl_config_to_mapping(
+    config: HookimplConfiguration,
+) -> dict[str, Any]:
+    """Serialize configuration to a legacy mapping (pytest/support only)."""
+    return {
+        "wrapper": config.wrapper,
+        "hookwrapper": config.hookwrapper,
+        "optionalhook": config.optionalhook,
+        "tryfirst": config.tryfirst,
+        "trylast": config.trylast,
+        "specname": config.specname,
+    }

--- a/src/pluggy/_decorators.py
+++ b/src/pluggy/_decorators.py
@@ -17,8 +17,8 @@ from typing import TypeAlias
 from typing import TypeVar
 import warnings
 
-from ._config import HookimplOpts
-from ._config import HookspecOpts
+from ._config import HookimplConfiguration
+from ._config import HookspecConfiguration
 
 
 _F = TypeVar("_F", bound=Callable[..., object])
@@ -96,15 +96,13 @@ class HookspecMarker:
         """
 
         def setattr_hookspec_opts(func: _F) -> _F:
-            if historic and firstresult:
-                raise ValueError("cannot have a historic firstresult hook")
-            opts: HookspecOpts = {
-                "firstresult": firstresult,
-                "historic": historic,
-                "warn_on_impl": warn_on_impl,
-                "warn_on_impl_args": warn_on_impl_args,
-            }
-            setattr(func, self.project_name + "_spec", opts)
+            config = HookspecConfiguration(
+                firstresult=firstresult,
+                historic=historic,
+                warn_on_impl=warn_on_impl,
+                warn_on_impl_args=warn_on_impl_args,
+            )
+            setattr(func, self.project_name + "_spec", config)
             return func
 
         if function is not None:
@@ -213,15 +211,15 @@ class HookimplMarker:
         """
 
         def setattr_hookimpl_opts(func: _F) -> _F:
-            opts: HookimplOpts = {
-                "wrapper": wrapper,
-                "hookwrapper": hookwrapper,
-                "optionalhook": optionalhook,
-                "tryfirst": tryfirst,
-                "trylast": trylast,
-                "specname": specname,
-            }
-            setattr(func, self.project_name + "_impl", opts)
+            config = HookimplConfiguration(
+                wrapper=wrapper,
+                hookwrapper=hookwrapper,
+                optionalhook=optionalhook,
+                tryfirst=tryfirst,
+                trylast=trylast,
+                specname=specname,
+            )
+            setattr(func, self.project_name + "_impl", config)
             return func
 
         if function is None:
@@ -338,7 +336,9 @@ class HookSpec:
         "warn_on_impl_args",
     )
 
-    def __init__(self, namespace: _Namespace, name: str, opts: HookspecOpts) -> None:
+    def __init__(
+        self, namespace: _Namespace, name: str, opts: HookspecConfiguration
+    ) -> None:
         self.namespace = namespace
         self.name = name
         self.function: Callable[..., object] = getattr(namespace, name)
@@ -349,5 +349,5 @@ class HookSpec:
             self.function, legacy_noself=legacy_noself
         )
         self.opts = opts
-        self.warn_on_impl = opts.get("warn_on_impl")
-        self.warn_on_impl_args = opts.get("warn_on_impl_args")
+        self.warn_on_impl = opts.warn_on_impl
+        self.warn_on_impl_args = opts.warn_on_impl_args

--- a/src/pluggy/_hooks.py
+++ b/src/pluggy/_hooks.py
@@ -13,9 +13,8 @@ from ._caller import _HookRelay
 from ._caller import _SubsetHookCaller
 from ._caller import HookCaller
 from ._caller import HookRelay
-from ._config import HookimplOpts
-from ._config import HookspecOpts
-from ._config import normalize_hookimpl_opts
+from ._config import HookimplConfiguration
+from ._config import HookspecConfiguration
 from ._decorators import _Namespace
 from ._decorators import HookimplMarker
 from ._decorators import HookSpec
@@ -31,10 +30,10 @@ __all__ = [
     "HookImpl",
     "HookRelay",
     "HookSpec",
+    "HookimplConfiguration",
     "HookimplMarker",
-    "HookimplOpts",
+    "HookspecConfiguration",
     "HookspecMarker",
-    "HookspecOpts",
     "_HookCaller",
     "_HookExec",
     "_HookImplFunction",
@@ -42,6 +41,5 @@ __all__ = [
     "_Namespace",
     "_Plugin",
     "_SubsetHookCaller",
-    "normalize_hookimpl_opts",
     "varnames",
 ]

--- a/src/pluggy/_implementation.py
+++ b/src/pluggy/_implementation.py
@@ -11,7 +11,7 @@ from typing import final
 from typing import TypeAlias
 from typing import TypeVar
 
-from ._config import HookimplOpts
+from ._config import HookimplConfiguration
 from ._decorators import varnames
 from ._result import Result
 
@@ -45,7 +45,7 @@ class HookImpl:
         plugin: _Plugin,
         plugin_name: str,
         function: _HookImplFunction[object],
-        hook_impl_opts: HookimplOpts,
+        hook_impl_opts: HookimplConfiguration,
     ) -> None:
         """:meta private:"""
         #: The hook implementation function.
@@ -57,24 +57,25 @@ class HookImpl:
         self.kwargnames: Final = kwargnames
         #: The plugin which defined this hook implementation.
         self.plugin: Final = plugin
-        #: The :class:`HookimplOpts` used to configure this hook implementation.
+        #: The :class:`HookimplConfiguration` used to configure this hook
+        #: implementation.
         self.opts: Final = hook_impl_opts
         #: The name of the plugin which defined this hook implementation.
         self.plugin_name: Final = plugin_name
         #: Whether the hook implementation is a :ref:`wrapper <hookwrapper>`.
-        self.wrapper: Final = hook_impl_opts["wrapper"]
+        self.wrapper: Final = hook_impl_opts.wrapper
         #: Whether the hook implementation is an :ref:`old-style wrapper
         #: <old_style_hookwrappers>`.
-        self.hookwrapper: Final = hook_impl_opts["hookwrapper"]
+        self.hookwrapper: Final = hook_impl_opts.hookwrapper
         #: Whether validation against a hook specification is :ref:`optional
         #: <optionalhook>`.
-        self.optionalhook: Final = hook_impl_opts["optionalhook"]
+        self.optionalhook: Final = hook_impl_opts.optionalhook
         #: Whether to try to order this hook implementation :ref:`first
         #: <callorder>`.
-        self.tryfirst: Final = hook_impl_opts["tryfirst"]
+        self.tryfirst: Final = hook_impl_opts.tryfirst
         #: Whether to try to order this hook implementation :ref:`last
         #: <callorder>`.
-        self.trylast: Final = hook_impl_opts["trylast"]
+        self.trylast: Final = hook_impl_opts.trylast
 
     def __repr__(self) -> str:
         return f"<HookImpl plugin_name={self.plugin_name!r}, plugin={self.plugin!r}>"

--- a/src/pluggy/_manager.py
+++ b/src/pluggy/_manager.py
@@ -15,16 +15,21 @@ import warnings
 
 from . import _tracing
 from ._callers import _multicall
+from ._config import hookimpl_config_from_mapping
+from ._config import hookimpl_config_to_mapping
+from ._config import HookimplConfiguration
+from ._config import hookspec_config_from_mapping
+from ._config import hookspec_config_to_mapping
+from ._config import HookspecConfiguration
 from ._hooks import _HookImplFunction
 from ._hooks import _Namespace
 from ._hooks import _Plugin
 from ._hooks import _SubsetHookCaller
 from ._hooks import HookCaller
 from ._hooks import HookImpl
-from ._hooks import HookimplOpts
 from ._hooks import HookRelay
-from ._hooks import HookspecOpts
-from ._hooks import normalize_hookimpl_opts
+from ._pytest_compat import HookimplOpts
+from ._pytest_compat import HookspecOpts
 from ._result import Result
 
 
@@ -142,12 +147,11 @@ class PluginManager:
 
         # register matching hook implementations of the plugin
         for attr_name in dir(plugin):
-            hookimpl_opts = self.parse_hookimpl_opts(plugin, attr_name)
-            if hookimpl_opts is not None:
-                normalize_hookimpl_opts(hookimpl_opts)
+            hookimpl_config = self._discover_hookimpl_configuration(plugin, attr_name)
+            if hookimpl_config is not None:
                 method: _HookImplFunction[object] = getattr(plugin, attr_name)
-                hookimpl = HookImpl(plugin, plugin_name, method, hookimpl_opts)
-                hook_name = hookimpl_opts.get("specname") or attr_name
+                hookimpl = HookImpl(plugin, plugin_name, method, hookimpl_config)
+                hook_name = hookimpl_config.specname or attr_name
                 hook: HookCaller | None = getattr(self.hook, hook_name, None)
                 if hook is None:
                     hook = HookCaller(hook_name, self._hookexec)
@@ -158,30 +162,61 @@ class PluginManager:
                 hook._add_hookimpl(hookimpl)
         return plugin_name
 
-    def parse_hookimpl_opts(self, plugin: _Plugin, name: str) -> HookimplOpts | None:
-        """Try to obtain a hook implementation from an item with the given name
-        in the given plugin which is being searched for hook impls.
-
-        :returns:
-            The parsed hookimpl options, or None to skip the given item.
-
-        This method can be overridden by ``PluginManager`` subclasses to
-        customize how hook implementation are picked up. By default, returns the
-        options for items decorated with :class:`HookimplMarker`.
-        """
-        method: object = getattr(plugin, name)
+    def _read_hookimpl_configuration(
+        self, plugin: _Plugin, name: str
+    ) -> HookimplConfiguration | None:
+        """Read a modern :class:`HookimplConfiguration` from a plugin attribute."""
+        try:
+            method: object = getattr(plugin, name)
+        except Exception:
+            # dir() can include properties that are not safely readable yet
+            # (e.g. pytest Config during early registration).
+            return None
         if not inspect.isroutine(method):
             return None
         try:
-            res: HookimplOpts | None = getattr(
-                method, self.project_name + "_impl", None
-            )
+            res: object = getattr(method, self.project_name + "_impl", None)
         except Exception:  # pragma: no cover
-            res = {}  # type: ignore[assignment] #pragma: no cover
-        if res is not None and not isinstance(res, dict):
-            # false positive
-            res = None  # type:ignore[unreachable] #pragma: no cover
-        return res
+            return None
+        if isinstance(res, HookimplConfiguration):
+            return res
+        if isinstance(res, Mapping):
+            return hookimpl_config_from_mapping(res)
+        return None
+
+    def _discover_hookimpl_configuration(
+        self, plugin: _Plugin, name: str
+    ) -> HookimplConfiguration | None:
+        """Discover hookimpl configuration for registration.
+
+        Prefer the modern marker attribute. Only call the deprecated
+        :meth:`parse_hookimpl_opts` when a subclass actually overrides it and
+        no modern configuration was found (pytest unmarked-hook concession).
+        """
+        config = self._read_hookimpl_configuration(plugin, name)
+        if config is not None:
+            return config
+        parse_hookimpl_opts = type(self).parse_hookimpl_opts
+        if parse_hookimpl_opts is PluginManager.parse_hookimpl_opts:
+            return None
+        legacy = parse_hookimpl_opts(self, plugin, name)
+        if legacy is None:
+            return None
+        return hookimpl_config_from_mapping(legacy)
+
+    def parse_hookimpl_opts(self, plugin: _Plugin, name: str) -> HookimplOpts | None:
+        """Return legacy dict-shaped hookimpl options, if any.
+
+        .. deprecated::
+            Thin pytest/support concession. Registration uses private discovery
+            of :class:`HookimplConfiguration` and only invokes this method when
+            a subclass overrides it and no modern configuration attribute was
+            found. Prefer marker-attached configuration objects.
+        """
+        config = self._read_hookimpl_configuration(plugin, name)
+        if config is None:
+            return None
+        return cast(HookimplOpts, hookimpl_config_to_mapping(config))
 
     def unregister(
         self, plugin: _Plugin | None = None, name: str | None = None
@@ -242,15 +277,15 @@ class PluginManager:
         """
         names = []
         for name in dir(module_or_class):
-            spec_opts = self.parse_hookspec_opts(module_or_class, name)
-            if spec_opts is not None:
+            spec_config = self._discover_hookspec_configuration(module_or_class, name)
+            if spec_config is not None:
                 hc: HookCaller | None = getattr(self.hook, name, None)
                 if hc is None:
-                    hc = HookCaller(name, self._hookexec, module_or_class, spec_opts)
+                    hc = HookCaller(name, self._hookexec, module_or_class, spec_config)
                     setattr(self.hook, name, hc)
                 else:
                     # Plugins registered this hook without knowing the spec.
-                    hc.set_specification(module_or_class, spec_opts)
+                    hc.set_specification(module_or_class, spec_config)
                     for hookfunction in hc.get_hookimpls():
                         self._verify_hook(hc, hookfunction)
                 names.append(name)
@@ -260,23 +295,59 @@ class PluginManager:
                 f"did not find any {self.project_name!r} hooks in {module_or_class!r}"
             )
 
+    def _read_hookspec_configuration(
+        self, module_or_class: _Namespace, name: str
+    ) -> HookspecConfiguration | None:
+        """Read a modern :class:`HookspecConfiguration` from a marked function."""
+        try:
+            method = getattr(module_or_class, name)
+        except Exception:
+            return None
+        try:
+            opts: object = getattr(method, self.project_name + "_spec", None)
+        except Exception:  # pragma: no cover
+            return None
+        if isinstance(opts, HookspecConfiguration):
+            return opts
+        if isinstance(opts, Mapping):
+            return hookspec_config_from_mapping(opts)
+        return None
+
+    def _discover_hookspec_configuration(
+        self, module_or_class: _Namespace, name: str
+    ) -> HookspecConfiguration | None:
+        """Discover hookspec configuration for ``add_hookspecs``.
+
+        Prefer the modern marker attribute. Only call the deprecated
+        :meth:`parse_hookspec_opts` when a subclass actually overrides it and
+        no modern configuration was found.
+        """
+        config = self._read_hookspec_configuration(module_or_class, name)
+        if config is not None:
+            return config
+        parse_hookspec_opts = type(self).parse_hookspec_opts
+        if parse_hookspec_opts is PluginManager.parse_hookspec_opts:
+            return None
+        legacy = parse_hookspec_opts(self, module_or_class, name)
+        if legacy is None:
+            return None
+        return hookspec_config_from_mapping(legacy)
+
     def parse_hookspec_opts(
         self, module_or_class: _Namespace, name: str
     ) -> HookspecOpts | None:
-        """Try to obtain a hook specification from an item with the given name
-        in the given module or class which is being searched for hook specs.
+        """Return legacy dict-shaped hookspec options, if any.
 
-        :returns:
-            The parsed hookspec options for defining a hook, or None to skip the
-            given item.
-
-        This method can be overridden by ``PluginManager`` subclasses to
-        customize how hook specifications are picked up. By default, returns the
-        options for items decorated with :class:`HookspecMarker`.
+        .. deprecated::
+            Thin pytest/support concession. ``add_hookspecs`` uses private
+            discovery of :class:`HookspecConfiguration` and only invokes this
+            method when a subclass overrides it and no modern configuration
+            attribute was found. Prefer marker-attached configuration objects.
         """
-        method = getattr(module_or_class, name)
-        opts: HookspecOpts | None = getattr(method, self.project_name + "_spec", None)
-        return opts
+        config = self._read_hookspec_configuration(module_or_class, name)
+        if config is None:
+            return None
+        return cast(HookspecOpts, hookspec_config_to_mapping(config))
 
     def get_plugins(self) -> set[Any]:
         """Return a set of all registered plugin objects."""

--- a/src/pluggy/_pytest_compat.py
+++ b/src/pluggy/_pytest_compat.py
@@ -1,0 +1,55 @@
+"""Pytest/support compatibility helpers for legacy option encodings.
+
+The live pluggy API uses :class:`~pluggy.HookspecConfiguration` and
+:class:`~pluggy.HookimplConfiguration`. This module keeps TypedDict shapes and
+mapping conversion for pytest and other callers that still type or attach
+dict-shaped options during migration.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TypedDict
+
+from ._config import hookimpl_config_from_mapping
+from ._config import HookimplConfiguration
+from ._config import hookspec_config_from_mapping
+from ._config import HookspecConfiguration
+
+
+class HookspecOpts(TypedDict):
+    """Legacy TypedDict for hook specification options.
+
+    Prefer :class:`~pluggy.HookspecConfiguration`. Kept for pytest/typing
+    compatibility during migration.
+    """
+
+    firstresult: bool
+    historic: bool
+    warn_on_impl: Warning | None
+    warn_on_impl_args: Mapping[str, Warning] | None
+
+
+class HookimplOpts(TypedDict):
+    """Legacy TypedDict for hook implementation options.
+
+    Prefer :class:`~pluggy.HookimplConfiguration`. Kept for pytest/typing
+    compatibility during migration.
+    """
+
+    wrapper: bool
+    hookwrapper: bool
+    optionalhook: bool
+    tryfirst: bool
+    trylast: bool
+    specname: str | None
+
+
+__all__ = [
+    "HookimplConfiguration",
+    "HookimplOpts",
+    "HookspecConfiguration",
+    "HookspecOpts",
+    "hookimpl_config_from_mapping",
+    "hookspec_config_from_mapping",
+]

--- a/testing/test_configuration.py
+++ b/testing/test_configuration.py
@@ -1,0 +1,278 @@
+"""
+Tests for configuration classes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pluggy import HookimplConfiguration
+from pluggy import HookimplMarker
+from pluggy import HookspecConfiguration
+from pluggy import HookspecMarker
+from pluggy import PluginManager
+from pluggy._config import hookimpl_config_from_mapping
+from pluggy._config import hookspec_config_from_mapping
+
+
+class TestHookspecConfiguration:
+    def test_basic_creation(self) -> None:
+        config = HookspecConfiguration()
+        assert config.firstresult is False
+        assert config.historic is False
+        assert config.warn_on_impl is None
+        assert config.warn_on_impl_args is None
+
+    def test_firstresult(self) -> None:
+        config = HookspecConfiguration(firstresult=True)
+        assert config.firstresult is True
+        assert config.historic is False
+
+    def test_historic(self) -> None:
+        config = HookspecConfiguration(historic=True)
+        assert config.firstresult is False
+        assert config.historic is True
+
+    def test_historic_firstresult_validation(self) -> None:
+        with pytest.raises(ValueError, match="cannot have a historic firstresult"):
+            HookspecConfiguration(historic=True, firstresult=True)
+
+    def test_warn_on_impl(self) -> None:
+        warning = UserWarning("test warning")
+        config = HookspecConfiguration(warn_on_impl=warning)
+        assert config.warn_on_impl is warning
+
+    def test_warn_on_impl_args(self) -> None:
+        warnings_dict = {"arg1": UserWarning("arg1 warning")}
+        config = HookspecConfiguration(warn_on_impl_args=warnings_dict)
+        assert config.warn_on_impl_args is warnings_dict
+
+
+class TestHookimplConfiguration:
+    def test_basic_creation(self) -> None:
+        config = HookimplConfiguration()
+        assert config.wrapper is False
+        assert config.hookwrapper is False
+        assert config.optionalhook is False
+        assert config.tryfirst is False
+        assert config.trylast is False
+        assert config.specname is None
+
+    def test_wrapper(self) -> None:
+        config = HookimplConfiguration(wrapper=True)
+        assert config.wrapper is True
+        assert config.hookwrapper is False
+
+    def test_hookwrapper(self) -> None:
+        config = HookimplConfiguration(hookwrapper=True)
+        assert config.wrapper is False
+        assert config.hookwrapper is True
+
+    def test_both_wrappers_allowed(self) -> None:
+        """Both wrapper types are allowed at config level; validation is later."""
+        config = HookimplConfiguration(wrapper=True, hookwrapper=True)
+        assert config.wrapper is True
+        assert config.hookwrapper is True
+
+    def test_tryfirst(self) -> None:
+        config = HookimplConfiguration(tryfirst=True)
+        assert config.tryfirst is True
+        assert config.trylast is False
+
+    def test_trylast(self) -> None:
+        config = HookimplConfiguration(trylast=True)
+        assert config.tryfirst is False
+        assert config.trylast is True
+
+    def test_optionalhook(self) -> None:
+        config = HookimplConfiguration(optionalhook=True)
+        assert config.optionalhook is True
+
+    def test_specname(self) -> None:
+        config = HookimplConfiguration(specname="custom_name")
+        assert config.specname == "custom_name"
+
+
+class TestMappingShim:
+    def test_hookspec_config_from_mapping(self) -> None:
+        warning = UserWarning("w")
+        config = hookspec_config_from_mapping(
+            {
+                "firstresult": True,
+                "warn_on_impl": warning,
+            }
+        )
+        assert config.firstresult is True
+        assert config.historic is False
+        assert config.warn_on_impl is warning
+
+    def test_hookimpl_config_from_mapping(self) -> None:
+        config = hookimpl_config_from_mapping(
+            {
+                "tryfirst": True,
+                "specname": "other",
+            }
+        )
+        assert config.tryfirst is True
+        assert config.specname == "other"
+        assert config.wrapper is False
+
+    def test_read_hookimpl_accepts_legacy_dict_attribute(self) -> None:
+        pm = PluginManager("test")
+
+        def method() -> str:
+            return "ok"
+
+        # setattr, not attribute access: the marker is dynamic and must not
+        # be type-checked against the function object.
+        setattr(method, "test_impl", {"tryfirst": True})  # noqa: B010
+
+        class Plugin:
+            pass
+
+        plugin = Plugin()
+        plugin.method = method  # type: ignore[attr-defined]
+        config = pm._read_hookimpl_configuration(plugin, "method")
+        assert isinstance(config, HookimplConfiguration)
+        assert config.tryfirst is True
+
+    def test_parse_hookimpl_opts_returns_legacy_dict(self) -> None:
+        hookimpl = HookimplMarker("test")
+
+        @hookimpl(tryfirst=True)
+        def method() -> str:
+            return "ok"
+
+        class Plugin:
+            pass
+
+        plugin = Plugin()
+        plugin.method = method  # type: ignore[attr-defined]
+        opts = PluginManager("test").parse_hookimpl_opts(plugin, "method")
+        assert opts == {
+            "wrapper": False,
+            "hookwrapper": False,
+            "optionalhook": False,
+            "tryfirst": True,
+            "trylast": False,
+            "specname": None,
+        }
+
+    def test_read_hookspec_accepts_legacy_dict_attribute(self) -> None:
+        pm = PluginManager("test")
+
+        class Spec:
+            def myhook(self) -> None:
+                pass
+
+        setattr(Spec.myhook, "test_spec", {"firstresult": True})  # noqa: B010
+        config = pm._read_hookspec_configuration(Spec, "myhook")
+        assert isinstance(config, HookspecConfiguration)
+        assert config.firstresult is True
+
+    def test_discover_skips_parse_hookimpl_opts_unless_overridden(self) -> None:
+        calls: list[str] = []
+
+        class TrackingPluginManager(PluginManager):
+            def parse_hookimpl_opts(self, plugin: object, name: str):
+                calls.append(name)
+                return super().parse_hookimpl_opts(plugin, name)
+
+        class Spec:
+            @HookspecMarker("test")
+            def marked(self) -> None:
+                pass
+
+            def unmarked(self) -> None:
+                pass
+
+        class Plugin:
+            @HookimplMarker("test")
+            def marked(self) -> str:
+                return "marked"
+
+            def unmarked(self) -> str:
+                return "unmarked"
+
+        pm = TrackingPluginManager("test")
+        pm.add_hookspecs(Spec)
+        pm.register(Plugin())
+        # Marked impl is discovered privately; unmarked has no config and the
+        # override returns None, so parse_hookimpl_opts is only tried for names
+        # without a modern configuration attribute.
+        assert "marked" not in calls
+        assert "unmarked" in calls
+
+
+def test_markers_attach_configuration_objects() -> None:
+    hookspec = HookspecMarker("test")
+    hookimpl = HookimplMarker("test")
+
+    @hookspec(firstresult=True)
+    def myspec(arg: object) -> None:
+        pass
+
+    @hookimpl(tryfirst=True)
+    def myimpl(arg: object) -> str:
+        return "x"
+
+    spec_config = getattr(myspec, "test_spec")  # noqa: B009
+    impl_config = getattr(myimpl, "test_impl")  # noqa: B009
+    assert isinstance(spec_config, HookspecConfiguration)
+    assert spec_config.firstresult is True
+    assert isinstance(impl_config, HookimplConfiguration)
+    assert impl_config.tryfirst is True
+
+
+def test_config_integration_with_hooks() -> None:
+    pm = PluginManager("test")
+    hookspec = HookspecMarker("test")
+    hookimpl = HookimplMarker("test")
+
+    class MySpec:
+        @hookspec(firstresult=True)
+        def myhook(self, arg: object) -> None:
+            pass
+
+    class Plugin1:
+        @hookimpl(trylast=True)
+        def myhook(self, arg: object) -> str:
+            return f"plugin1: {arg}"
+
+    class Plugin2:
+        @hookimpl(tryfirst=True)
+        def myhook(self, arg: object) -> str:
+            return f"plugin2: {arg}"
+
+    pm.add_hookspecs(MySpec)
+    pm.register(Plugin1())
+    pm.register(Plugin2())
+
+    result = pm.hook.myhook(arg="test")
+    assert result == "plugin2: test"
+
+
+def test_historic_hook_configuration() -> None:
+    pm = PluginManager("test")
+    hookspec = HookspecMarker("test")
+    hookimpl = HookimplMarker("test")
+
+    results: list[str] = []
+
+    class MySpec:
+        @hookspec(historic=True)
+        def myhook(self, arg: object) -> None:
+            pass
+
+    pm.add_hookspecs(MySpec)
+    pm.hook.myhook.call_historic(
+        kwargs={"arg": "call1"}, result_callback=results.append
+    )
+
+    class Plugin1:
+        @hookimpl
+        def myhook(self, arg: object) -> str:
+            return f"plugin1: {arg}"
+
+    pm.register(Plugin1())
+    assert "plugin1: call1" in results

--- a/testing/test_details.py
+++ b/testing/test_details.py
@@ -16,9 +16,11 @@ def test_parse_hookimpl_override() -> None:
     class MyPluginManager(PluginManager):
         def parse_hookimpl_opts(self, module_or_class, name):
             opts = PluginManager.parse_hookimpl_opts(self, module_or_class, name)
-            if opts is None and name.startswith("x1"):
-                opts = {}  # type: ignore[assignment]
-            return opts
+            if opts is not None:
+                return opts
+            if name.startswith("x1"):
+                return {}
+            return None
 
     class Plugin:
         def x1meth(self):

--- a/testing/test_hookcaller.py
+++ b/testing/test_hookcaller.py
@@ -317,11 +317,11 @@ def test_hookspec(pm: PluginManager) -> None:
 
     pm.add_hookspecs(HookSpec)
     assert pm.hook.he_myhook1.spec is not None
-    assert not pm.hook.he_myhook1.spec.opts["firstresult"]
+    assert not pm.hook.he_myhook1.spec.opts.firstresult
     assert pm.hook.he_myhook2.spec is not None
-    assert pm.hook.he_myhook2.spec.opts["firstresult"]
+    assert pm.hook.he_myhook2.spec.opts.firstresult
     assert pm.hook.he_myhook3.spec is not None
-    assert not pm.hook.he_myhook3.spec.opts["firstresult"]
+    assert not pm.hook.he_myhook3.spec.opts.firstresult
 
 
 @pytest.mark.parametrize("name", ["hookwrapper", "optionalhook", "tryfirst", "trylast"])
@@ -332,7 +332,7 @@ def test_hookimpl(name: str, val: bool) -> None:
         pass
 
     if val:
-        assert he_myhook1.example_impl.get(name)
+        assert getattr(he_myhook1.example_impl, name)
     else:
         assert not hasattr(he_myhook1, name)
 


### PR DESCRIPTION
<!-- stack-links -->
**Review PR — step 2 of 7.**

This PR targets the previous step's branch, so its diff is *only* this step's change. Review happens here. The corresponding upstream PR, which is the one that actually merges, is pytest-dev/pluggy#704.

Merges happen upstream one step at a time, bottom-up. When step 2 lands upstream, this PR is closed and the rest of the stack is rebased onto the new `main`.

| Step | Branch | Review (downstream) | Merge (upstream) |
| --- | --- | --- | --- |
| 1 | `refactor/split-hook-modules` | RonnyPfannschmidt/pluggy#6 | pytest-dev/pluggy#703 |
| 2 | `refactor/configuration-objects` | RonnyPfannschmidt/pluggy#5 | pytest-dev/pluggy#704 **←** |
| 3 | `refactor/markers-attach-config` | RonnyPfannschmidt/pluggy#7 | pytest-dev/pluggy#706 |
| 4 | `refactor/hookimpl-wrapper-types` | RonnyPfannschmidt/pluggy#8 | pytest-dev/pluggy#707 |
| 5 | `refactor/hookcaller-and-execution` | RonnyPfannschmidt/pluggy#9 | pytest-dev/pluggy#708 |
| 6 | `refactor/project-spec` | RonnyPfannschmidt/pluggy#10 | pytest-dev/pluggy#709 |
| 7 | `refactor/async-submitter` | RonnyPfannschmidt/pluggy#11 | pytest-dev/pluggy#710 |
<!-- /stack-links -->

## Summary
- Add `HookspecConfiguration` / `HookimplConfiguration`; markers attach these objects
- Private `_discover_*` / `_read_*` own registration discovery
- `parse_hookimpl_opts` / `parse_hookspec_opts` kept as a **deprecated pytest concession** (legacy dicts), only invoked when a subclass overrides them and no modern config attribute was found
- TypedDicts remain importable via `_pytest_compat` for pytest typing

Stacked on `refactor/split-hook-modules` for reviewable incremental diff.

## Test plan
- [x] `uv run pytest` (164 passed)
- [x] `uv run pre-commit run -a`


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Replace legacy dict-based hook option encodings with configuration objects and preserve compatibility for pytest and other legacy callers.

New Features:
- Introduce HookspecConfiguration and HookimplConfiguration classes as the primary configuration carriers for hook specifications and implementations.
- Expose the new HookspecConfiguration and HookimplConfiguration types from the public pluggy package API.

Enhancements:
- Update decorators, hook calling, and plugin manager registration to use configuration objects instead of TypedDict mappings, with internal helpers to convert to and from legacy mappings.
- Adjust tests and hookcaller behavior to work with configuration objects, including attribute-style access to hook implementation flags.

Tests:
- Add a dedicated test suite for configuration classes, mapping shims, marker integration, and historic hook behavior.
- Adapt existing tests to validate the new configuration-based API and the behavior of overridden parse_hookimpl_opts implementations.

Chores:
- Introduce a _pytest_compat module housing legacy TypedDict definitions and mapping helpers to support pytest and other callers during migration.
