### PR TITLE
feat(decorators): attach Hook*Configuration objects on marked functions

### DIFF
--- a/changelog/706.trivial.rst
+++ b/changelog/706.trivial.rst
@@ -1,0 +1,3 @@
+``HookSpec`` now stores its :class:`pluggy.HookspecConfiguration` as
+``config``; the old ``opts`` attribute remains as a deprecated alias
+property.

--- a/src/pluggy/_caller.py
+++ b/src/pluggy/_caller.py
@@ -183,7 +183,7 @@ class HookCaller:
             "Cannot directly call a historic hook - use call_historic instead."
         )
         self._verify_all_args_are_provided(kwargs)
-        firstresult = self.spec.opts.firstresult if self.spec else False
+        firstresult = self.spec.config.firstresult if self.spec else False
         # Copy because plugins may register other plugins during iteration (#438).
         return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
 
@@ -238,7 +238,7 @@ class HookCaller:
             ):
                 i -= 1
             hookimpls.insert(i + 1, hookimpl)
-        firstresult = self.spec.opts.firstresult if self.spec else False
+        firstresult = self.spec.config.firstresult if self.spec else False
         return self._hookexec(self.name, hookimpls, kwargs, firstresult)
 
     def _maybe_apply_history(self, method: HookImpl) -> None:

--- a/src/pluggy/_decorators.py
+++ b/src/pluggy/_decorators.py
@@ -327,17 +327,17 @@ def varnames(
 class HookSpec:
     __slots__ = (
         "argnames",
+        "config",
         "function",
         "kwargnames",
         "name",
         "namespace",
-        "opts",
         "warn_on_impl",
         "warn_on_impl_args",
     )
 
     def __init__(
-        self, namespace: _Namespace, name: str, opts: HookspecConfiguration
+        self, namespace: _Namespace, name: str, config: HookspecConfiguration
     ) -> None:
         self.namespace = namespace
         self.name = name
@@ -348,6 +348,15 @@ class HookSpec:
         self.argnames, self.kwargnames = varnames(
             self.function, legacy_noself=legacy_noself
         )
-        self.opts = opts
-        self.warn_on_impl = opts.warn_on_impl
-        self.warn_on_impl_args = opts.warn_on_impl_args
+        self.config = config
+        self.warn_on_impl = config.warn_on_impl
+        self.warn_on_impl_args = config.warn_on_impl_args
+
+    @property
+    def opts(self) -> HookspecConfiguration:
+        """Alias for :attr:`config`.
+
+        .. deprecated::
+            Use :attr:`config` instead.
+        """
+        return self.config

--- a/testing/test_configuration.py
+++ b/testing/test_configuration.py
@@ -224,6 +224,34 @@ def test_markers_attach_configuration_objects() -> None:
     assert impl_config.tryfirst is True
 
 
+def test_historic_firstresult_raises_at_decoration_time() -> None:
+    hookspec = HookspecMarker("test")
+
+    with pytest.raises(ValueError, match="cannot have a historic firstresult"):
+
+        @hookspec(historic=True, firstresult=True)
+        def myspec() -> None:
+            pass
+
+
+def test_hookspec_stores_configuration() -> None:
+    pm = PluginManager("test")
+    hookspec = HookspecMarker("test")
+
+    class Spec:
+        @hookspec(firstresult=True)
+        def myhook(self, arg: object) -> None:
+            pass
+
+    pm.add_hookspecs(Spec)
+    spec = pm.hook.myhook.spec
+    assert spec is not None
+    assert isinstance(spec.config, HookspecConfiguration)
+    assert spec.config.firstresult is True
+    # Deprecated alias.
+    assert spec.opts is spec.config
+
+
 def test_config_integration_with_hooks() -> None:
     pm = PluginManager("test")
     hookspec = HookspecMarker("test")

--- a/testing/test_hookcaller.py
+++ b/testing/test_hookcaller.py
@@ -317,11 +317,11 @@ def test_hookspec(pm: PluginManager) -> None:
 
     pm.add_hookspecs(HookSpec)
     assert pm.hook.he_myhook1.spec is not None
-    assert not pm.hook.he_myhook1.spec.opts.firstresult
+    assert not pm.hook.he_myhook1.spec.config.firstresult
     assert pm.hook.he_myhook2.spec is not None
-    assert pm.hook.he_myhook2.spec.opts.firstresult
+    assert pm.hook.he_myhook2.spec.config.firstresult
     assert pm.hook.he_myhook3.spec is not None
-    assert not pm.hook.he_myhook3.spec.opts.firstresult
+    assert not pm.hook.he_myhook3.spec.config.firstresult
 
 
 @pytest.mark.parametrize("name", ["hookwrapper", "optionalhook", "tryfirst", "trylast"])


### PR DESCRIPTION
<!-- stack-links -->
**Review PR — step 3 of 7.**

This PR targets the previous step's branch, so its diff is *only* this step's change. Review happens here. The corresponding upstream PR, which is the one that actually merges, is pytest-dev/pluggy#706.

Merges happen upstream one step at a time, bottom-up. When step 3 lands upstream, this PR is closed and the rest of the stack is rebased onto the new `main`.

| Step | Branch | Review (downstream) | Merge (upstream) |
| --- | --- | --- | --- |
| 1 | `refactor/split-hook-modules` | RonnyPfannschmidt/pluggy#6 | pytest-dev/pluggy#703 |
| 2 | `refactor/configuration-objects` | RonnyPfannschmidt/pluggy#5 | pytest-dev/pluggy#704 |
| 3 | `refactor/markers-attach-config` | RonnyPfannschmidt/pluggy#7 | pytest-dev/pluggy#706 **←** |
| 4 | `refactor/hookimpl-wrapper-types` | RonnyPfannschmidt/pluggy#8 | pytest-dev/pluggy#707 |
| 5 | `refactor/hookcaller-and-execution` | RonnyPfannschmidt/pluggy#9 | pytest-dev/pluggy#708 |
| 6 | `refactor/project-spec` | RonnyPfannschmidt/pluggy#10 | pytest-dev/pluggy#709 |
| 7 | `refactor/async-submitter` | RonnyPfannschmidt/pluggy#11 | pytest-dev/pluggy#710 |
<!-- /stack-links -->

Chain step 03 of the internal-refactoring series (design/03-markers-attach-config.md).

Stores the spec configuration as HookSpec.config (deprecated .opts alias kept), reads .config in firstresult resolution, and adds decoration-time historic+firstresult validation tests.

Stacked on #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Attach and expose hook specification configuration objects on marked functions and shift usage from the deprecated opts attribute to config, including validation and tests for historic/firstresult behavior.

New Features:
- Store HookspecConfiguration as HookSpec.config on hook specifications and expose it via pm.hook.<name>.spec.

Enhancements:
- Add decoration-time validation to forbid hooks that are both historic and firstresult.
- Update hook calling logic to read firstresult from HookSpec.config instead of the deprecated opts attribute.
- Provide a deprecated HookSpec.opts property as an alias to config for backward compatibility.

Tests:
- Extend configuration tests to cover stored spec configuration and decoration-time errors for invalid historic/firstresult combinations.
- Update hook caller tests to assert firstresult behavior via the new HookSpec.config attribute.

Chores:
- Add a trivial changelog entry documenting the refactoring of hook specification configuration storage.
