### PR TITLE
feat(implementation): add NormalImpl, WrapperImpl, and CompletionHook setup API

### DIFF
--- a/changelog/707.feature.rst
+++ b/changelog/707.feature.rst
@@ -1,0 +1,9 @@
+Hook implementations are now represented by dedicated types:
+:class:`pluggy.NormalImpl` for normal implementations and
+:class:`pluggy.WrapperImpl` for (old- and new-style) wrappers, both
+subclasses of :class:`pluggy.HookImpl`.
+``HookimplConfiguration.create_hookimpl()`` selects the appropriate
+subclass, and ``WrapperImpl.setup_and_get_completion_hook()`` exposes
+wrapper setup/teardown as a ``CompletionHook`` callback.
+``HookImpl`` now stores its configuration as ``hookimpl_config``; the old
+``opts`` attribute remains as a deprecated alias property.

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -40,6 +40,14 @@ API Reference
 .. autoclass:: pluggy.HookImpl()
     :members:
 
+.. autoclass:: pluggy.NormalImpl()
+    :show-inheritance:
+    :members:
+
+.. autoclass:: pluggy.WrapperImpl()
+    :show-inheritance:
+    :members:
+
 .. autoclass:: pluggy.HookspecConfiguration()
     :members:
 

--- a/src/pluggy/__init__.py
+++ b/src/pluggy/__init__.py
@@ -9,11 +9,13 @@ __all__ = [
     "HookspecConfiguration",
     "HookspecMarker",
     "HookspecOpts",
+    "NormalImpl",
     "PluggyTeardownRaisedWarning",
     "PluggyWarning",
     "PluginManager",
     "PluginValidationError",
     "Result",
+    "WrapperImpl",
     "__version__",
 ]
 from ._config import HookimplConfiguration
@@ -23,6 +25,8 @@ from ._hooks import HookImpl
 from ._hooks import HookimplMarker
 from ._hooks import HookRelay
 from ._hooks import HookspecMarker
+from ._hooks import NormalImpl
+from ._hooks import WrapperImpl
 from ._manager import PluginManager
 from ._manager import PluginValidationError
 from ._pytest_compat import HookimplOpts

--- a/src/pluggy/_caller.py
+++ b/src/pluggy/_caller.py
@@ -224,10 +224,10 @@ class HookCaller:
             "Cannot directly call a historic hook - use call_historic instead."
         )
         self._verify_all_args_are_provided(kwargs)
-        opts = HookimplConfiguration()
+        config = HookimplConfiguration()
         hookimpls = self._hookimpls.copy()
         for method in methods:
-            hookimpl = HookImpl(None, "<temp>", method, opts)
+            hookimpl = config.create_hookimpl(None, "<temp>", method)
             # Find last non-tryfirst nonwrapper method.
             i = len(hookimpls) - 1
             while i >= 0 and (

--- a/src/pluggy/_config.py
+++ b/src/pluggy/_config.py
@@ -8,6 +8,14 @@ from collections.abc import Mapping
 from typing import Any
 from typing import Final
 from typing import final
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from ._implementation import _HookImplFunction
+    from ._implementation import _Plugin
+    from ._implementation import NormalImpl
+    from ._implementation import WrapperImpl
 
 
 @final
@@ -97,6 +105,27 @@ class HookimplConfiguration:
         self.trylast = trylast
         #: The name of the hook specification to match, see :ref:`specname`.
         self.specname = specname
+
+    def create_hookimpl(
+        self,
+        plugin: _Plugin,
+        plugin_name: str,
+        function: _HookImplFunction[object],
+    ) -> NormalImpl | WrapperImpl:
+        """Create the appropriate :class:`HookImpl` subclass for this
+        configuration.
+
+        Wrapper configurations produce a :class:`WrapperImpl`; all others
+        produce a :class:`NormalImpl`.
+        """
+        # Local import to avoid a circular import with the implementation
+        # module.
+        from ._implementation import NormalImpl
+        from ._implementation import WrapperImpl
+
+        if self.wrapper or self.hookwrapper:
+            return WrapperImpl(plugin, plugin_name, function, self)
+        return NormalImpl(plugin, plugin_name, function, self)
 
     def __repr__(self) -> str:
         attrs = [

--- a/src/pluggy/_execution.py
+++ b/src/pluggy/_execution.py
@@ -14,7 +14,6 @@ from typing import TypeAlias
 import warnings
 
 from ._implementation import HookImpl
-from ._result import HookCallError
 from ._result import Result
 from ._warnings import PluggyTeardownRaisedWarning
 
@@ -96,12 +95,7 @@ def _multicall(
     teardowns: list[Teardown] = []
     try:  # run impl and wrapper setup functions in a loop
         for hook_impl in reversed(hook_impls):
-            try:
-                args = [caller_kwargs[argname] for argname in hook_impl.argnames]
-            except KeyError as e:
-                raise HookCallError(
-                    f"hook call must provide argument {e.args[0]!r}"
-                ) from e
+            args = hook_impl._get_call_args(caller_kwargs)
 
             if hook_impl.hookwrapper:
                 function_gen = run_old_style_hookwrapper(hook_impl, hook_name, args)

--- a/src/pluggy/_hooks.py
+++ b/src/pluggy/_hooks.py
@@ -22,10 +22,14 @@ from ._decorators import HookspecMarker
 from ._decorators import varnames
 from ._implementation import _HookImplFunction
 from ._implementation import _Plugin
+from ._implementation import CompletionHook
 from ._implementation import HookImpl
+from ._implementation import NormalImpl
+from ._implementation import WrapperImpl
 
 
 __all__ = [
+    "CompletionHook",
     "HookCaller",
     "HookImpl",
     "HookRelay",
@@ -34,6 +38,8 @@ __all__ = [
     "HookimplMarker",
     "HookspecConfiguration",
     "HookspecMarker",
+    "NormalImpl",
+    "WrapperImpl",
     "_HookCaller",
     "_HookExec",
     "_HookImplFunction",

--- a/src/pluggy/_implementation.py
+++ b/src/pluggy/_implementation.py
@@ -6,13 +6,18 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from collections.abc import Generator
+from collections.abc import Mapping
+from typing import cast
 from typing import Final
 from typing import final
+from typing import Protocol
+from typing import runtime_checkable
 from typing import TypeAlias
 from typing import TypeVar
 
 from ._config import HookimplConfiguration
 from ._decorators import varnames
+from ._result import HookCallError
 from ._result import Result
 
 
@@ -22,17 +27,31 @@ _Plugin: TypeAlias = object
 _HookImplFunction: TypeAlias = Callable[..., _T | Generator[None, Result[_T], None]]
 
 
-@final
+@runtime_checkable
+class CompletionHook(Protocol):
+    """Teardown callback returned by :meth:`WrapperImpl.setup_and_get_completion_hook`.
+
+    Receives the current ``(result, exception)`` outcome of the hook call and
+    returns the possibly replaced ``(result, exception)`` pair.
+    """
+
+    def __call__(
+        self,
+        result: object | list[object] | None,
+        exception: BaseException | None,
+    ) -> tuple[object | list[object] | None, BaseException | None]: ...
+
+
 class HookImpl:
-    """A hook implementation in a :class:`HookCaller`."""
+    """Base class for hook implementations in a :class:`HookCaller`."""
 
     __slots__ = (
         "argnames",
         "function",
+        "hookimpl_config",
         "hookwrapper",
         "kwargnames",
         "optionalhook",
-        "opts",
         "plugin",
         "plugin_name",
         "tryfirst",
@@ -45,7 +64,7 @@ class HookImpl:
         plugin: _Plugin,
         plugin_name: str,
         function: _HookImplFunction[object],
-        hook_impl_opts: HookimplConfiguration,
+        hook_impl_config: HookimplConfiguration,
     ) -> None:
         """:meta private:"""
         #: The hook implementation function.
@@ -59,23 +78,147 @@ class HookImpl:
         self.plugin: Final = plugin
         #: The :class:`HookimplConfiguration` used to configure this hook
         #: implementation.
-        self.opts: Final = hook_impl_opts
+        self.hookimpl_config: Final = hook_impl_config
         #: The name of the plugin which defined this hook implementation.
         self.plugin_name: Final = plugin_name
         #: Whether the hook implementation is a :ref:`wrapper <hookwrapper>`.
-        self.wrapper: Final = hook_impl_opts.wrapper
+        self.wrapper: Final = hook_impl_config.wrapper
         #: Whether the hook implementation is an :ref:`old-style wrapper
         #: <old_style_hookwrappers>`.
-        self.hookwrapper: Final = hook_impl_opts.hookwrapper
+        self.hookwrapper: Final = hook_impl_config.hookwrapper
         #: Whether validation against a hook specification is :ref:`optional
         #: <optionalhook>`.
-        self.optionalhook: Final = hook_impl_opts.optionalhook
+        self.optionalhook: Final = hook_impl_config.optionalhook
         #: Whether to try to order this hook implementation :ref:`first
         #: <callorder>`.
-        self.tryfirst: Final = hook_impl_opts.tryfirst
+        self.tryfirst: Final = hook_impl_config.tryfirst
         #: Whether to try to order this hook implementation :ref:`last
         #: <callorder>`.
-        self.trylast: Final = hook_impl_opts.trylast
+        self.trylast: Final = hook_impl_config.trylast
+
+    @property
+    def opts(self) -> HookimplConfiguration:
+        """Alias for :attr:`hookimpl_config`.
+
+        .. deprecated::
+            Use :attr:`hookimpl_config` instead.
+        """
+        return self.hookimpl_config
+
+    def _get_call_args(self, caller_kwargs: Mapping[str, object]) -> list[object]:
+        """Extract the positional arguments for calling this hook implementation.
+
+        :raises HookCallError: If a required argument is missing.
+        """
+        try:
+            return [caller_kwargs[argname] for argname in self.argnames]
+        except KeyError as e:
+            raise HookCallError(f"hook call must provide argument {e.args[0]!r}") from e
 
     def __repr__(self) -> str:
-        return f"<HookImpl plugin_name={self.plugin_name!r}, plugin={self.plugin!r}>"
+        return (
+            f"<{type(self).__name__} "
+            f"plugin_name={self.plugin_name!r}, plugin={self.plugin!r}>"
+        )
+
+
+@final
+class NormalImpl(HookImpl):
+    """A normal (non-wrapper) hook implementation in a :class:`HookCaller`."""
+
+    def __init__(
+        self,
+        plugin: _Plugin,
+        plugin_name: str,
+        function: _HookImplFunction[object],
+        hook_impl_config: HookimplConfiguration,
+    ) -> None:
+        """:meta private:"""
+        if hook_impl_config.wrapper or hook_impl_config.hookwrapper:
+            raise ValueError(
+                "NormalImpl cannot be used for wrapper implementations. "
+                "Use WrapperImpl instead."
+            )
+        super().__init__(plugin, plugin_name, function, hook_impl_config)
+
+
+@final
+class WrapperImpl(HookImpl):
+    """A wrapper hook implementation in a :class:`HookCaller`."""
+
+    def __init__(
+        self,
+        plugin: _Plugin,
+        plugin_name: str,
+        function: _HookImplFunction[object],
+        hook_impl_config: HookimplConfiguration,
+    ) -> None:
+        """:meta private:"""
+        if not (hook_impl_config.wrapper or hook_impl_config.hookwrapper):
+            raise ValueError(
+                "WrapperImpl can only be used for wrapper implementations. "
+                "Use NormalImpl for normal implementations."
+            )
+        super().__init__(plugin, plugin_name, function, hook_impl_config)
+
+    def setup_and_get_completion_hook(
+        self, hook_name: str, caller_kwargs: Mapping[str, object]
+    ) -> CompletionHook:
+        """Run the wrapper setup phase and return its :class:`CompletionHook`.
+
+        Old-style hookwrappers and new-style wrappers are handled uniformly by
+        adapting old-style wrappers via ``run_old_style_hookwrapper``.
+
+        The returned completion hook performs the teardown: it sends the
+        current outcome into the wrapper generator (or throws the current
+        exception) and returns the possibly replaced ``(result, exception)``
+        pair.
+        """
+        # Local import to avoid a circular import with the execution module.
+        from ._execution import _raise_wrapfail
+        from ._execution import run_old_style_hookwrapper
+
+        args = self._get_call_args(caller_kwargs)
+
+        wrapper_gen: Generator[None, object, object]
+        if self.hookwrapper:
+            wrapper_gen = run_old_style_hookwrapper(self, hook_name, args)
+        else:
+            wrapper_gen = cast(Generator[None, object, object], self.function(*args))
+
+        try:
+            next(wrapper_gen)  # first yield / setup phase
+        except StopIteration:
+            _raise_wrapfail(wrapper_gen, "did not yield")
+
+        def completion_hook(
+            result: object | list[object] | None, exception: BaseException | None
+        ) -> tuple[object | list[object] | None, BaseException | None]:
+            try:
+                if exception is not None:
+                    try:
+                        wrapper_gen.throw(exception)
+                    except RuntimeError as re:
+                        # StopIteration from generator causes RuntimeError
+                        # even for coroutine usage - see #544
+                        if (
+                            isinstance(exception, StopIteration)
+                            and re.__cause__ is exception
+                        ):
+                            wrapper_gen.close()
+                            return result, exception
+                        else:
+                            raise
+                else:
+                    wrapper_gen.send(result)
+                # Following is unreachable for a well behaved hook wrapper.
+                # Try to force finalizers otherwise postponed till GC action.
+                # Note: close() may raise if generator handles GeneratorExit.
+                wrapper_gen.close()
+                _raise_wrapfail(wrapper_gen, "has second yield")
+            except StopIteration as si:
+                return si.value, None
+            except BaseException as e:
+                return result, e
+
+        return completion_hook

--- a/src/pluggy/_manager.py
+++ b/src/pluggy/_manager.py
@@ -150,7 +150,7 @@ class PluginManager:
             hookimpl_config = self._discover_hookimpl_configuration(plugin, attr_name)
             if hookimpl_config is not None:
                 method: _HookImplFunction[object] = getattr(plugin, attr_name)
-                hookimpl = HookImpl(plugin, plugin_name, method, hookimpl_config)
+                hookimpl = hookimpl_config.create_hookimpl(plugin, plugin_name, method)
                 hook_name = hookimpl_config.specname or attr_name
                 hook: HookCaller | None = getattr(self.hook, hook_name, None)
                 if hook is None:

--- a/testing/test_details.py
+++ b/testing/test_details.py
@@ -193,7 +193,7 @@ def test_repr() -> None:
     plugin = Plugin()
     pname = pm.register(plugin)
     assert repr(pm.hook.myhook.get_hookimpls()[0]) == (
-        f"<HookImpl plugin_name={pname!r}, plugin={plugin!r}>"
+        f"<NormalImpl plugin_name={pname!r}, plugin={plugin!r}>"
     )
 
 

--- a/testing/test_implementation.py
+++ b/testing/test_implementation.py
@@ -1,0 +1,218 @@
+"""
+Tests for the HookImpl hierarchy and the CompletionHook setup API.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from collections.abc import Generator
+from typing import Any
+
+import pytest
+
+from pluggy import HookCallError
+from pluggy import HookImpl
+from pluggy import HookimplConfiguration
+from pluggy import HookimplMarker
+from pluggy import HookspecMarker
+from pluggy import NormalImpl
+from pluggy import PluginManager
+from pluggy import WrapperImpl
+from pluggy._implementation import CompletionHook
+
+
+hookspec = HookspecMarker("example")
+hookimpl = HookimplMarker("example")
+
+
+def func(arg: object) -> object:
+    return arg
+
+
+def wrapper_func(arg: object) -> Generator[None, object, object]:
+    return (yield)
+
+
+class TestCreateHookimpl:
+    def test_normal_config_returns_normal_impl(self) -> None:
+        config = HookimplConfiguration()
+        impl = config.create_hookimpl(None, "test", func)
+        assert type(impl) is NormalImpl
+        assert isinstance(impl, HookImpl)
+        assert impl.hookimpl_config is config
+
+    def test_wrapper_config_returns_wrapper_impl(self) -> None:
+        config = HookimplConfiguration(wrapper=True)
+        impl = config.create_hookimpl(None, "test", wrapper_func)
+        assert type(impl) is WrapperImpl
+
+    def test_hookwrapper_config_returns_wrapper_impl(self) -> None:
+        config = HookimplConfiguration(hookwrapper=True)
+        impl = config.create_hookimpl(None, "test", wrapper_func)
+        assert type(impl) is WrapperImpl
+
+    def test_normal_impl_rejects_wrapper_config(self) -> None:
+        config = HookimplConfiguration(wrapper=True)
+        with pytest.raises(ValueError, match="Use WrapperImpl"):
+            NormalImpl(None, "test", wrapper_func, config)
+
+    def test_wrapper_impl_rejects_normal_config(self) -> None:
+        config = HookimplConfiguration()
+        with pytest.raises(ValueError, match="Use NormalImpl"):
+            WrapperImpl(None, "test", func, config)
+
+    def test_opts_alias(self) -> None:
+        config = HookimplConfiguration(tryfirst=True)
+        impl = config.create_hookimpl(None, "test", func)
+        assert impl.opts is config
+
+
+class TestGetCallArgs:
+    def test_binds_in_argname_order(self) -> None:
+        def f(b: object, a: object) -> None:
+            pass
+
+        impl = HookimplConfiguration().create_hookimpl(None, "test", f)
+        assert impl._get_call_args({"a": 1, "b": 2, "extra": 3}) == [2, 1]
+
+    def test_missing_argument_raises_hook_call_error(self) -> None:
+        impl = HookimplConfiguration().create_hookimpl(None, "test", func)
+        with pytest.raises(HookCallError, match="must provide argument 'arg'"):
+            impl._get_call_args({})
+
+
+def make_wrapper_impl(
+    function: Callable[..., Any], *, hookwrapper: bool = False
+) -> WrapperImpl:
+    config = HookimplConfiguration(wrapper=not hookwrapper, hookwrapper=hookwrapper)
+    impl = config.create_hookimpl(None, "test", function)
+    assert isinstance(impl, WrapperImpl)
+    return impl
+
+
+class TestSetupAndGetCompletionHook:
+    def test_returns_completion_hook_protocol_instance(self) -> None:
+        impl = make_wrapper_impl(wrapper_func)
+        completion = impl.setup_and_get_completion_hook("myhook", {"arg": 1})
+        assert isinstance(completion, CompletionHook)
+        assert completion(21, None) == (21, None)
+
+    def test_setup_runs_code_before_yield(self) -> None:
+        events: list[str] = []
+
+        def wrapper() -> Generator[None, object, object]:
+            events.append("setup")
+            res = yield
+            events.append("teardown")
+            return res
+
+        impl = make_wrapper_impl(wrapper)
+        completion = impl.setup_and_get_completion_hook("myhook", {})
+        assert events == ["setup"]
+        assert completion("x", None) == ("x", None)
+        assert events == ["setup", "teardown"]
+
+    def test_completion_replaces_result(self) -> None:
+        def wrapper() -> Generator[None, object, object]:
+            res = yield
+            assert isinstance(res, int)
+            return res + 1
+
+        impl = make_wrapper_impl(wrapper)
+        completion = impl.setup_and_get_completion_hook("myhook", {})
+        assert completion(41, None) == (42, None)
+
+    def test_completion_can_swallow_exception(self) -> None:
+        def wrapper() -> Generator[None, object, object]:
+            try:
+                yield
+            except ValueError:
+                return "fallback"
+            raise AssertionError("unreachable")
+
+        impl = make_wrapper_impl(wrapper)
+        completion = impl.setup_and_get_completion_hook("myhook", {})
+        result, exception = completion(None, ValueError("boom"))
+        assert result == "fallback"
+        assert exception is None
+
+    def test_completion_passes_through_unhandled_exception(self) -> None:
+        impl = make_wrapper_impl(wrapper_func)
+        completion = impl.setup_and_get_completion_hook("myhook", {"arg": 1})
+        exc = ValueError("boom")
+        result, exception = completion("kept", exc)
+        assert result == "kept"
+        assert exception is exc
+
+    def test_completion_can_raise_new_exception(self) -> None:
+        def wrapper() -> Generator[None, object, object]:
+            yield
+            raise RuntimeError("replaced")
+
+        impl = make_wrapper_impl(wrapper)
+        completion = impl.setup_and_get_completion_hook("myhook", {})
+        result, exception = completion("x", None)
+        assert result == "x"
+        assert isinstance(exception, RuntimeError)
+        assert str(exception) == "replaced"
+
+    def test_did_not_yield_raises(self) -> None:
+        def no_yield() -> Generator[None, object, object]:
+            return "nope"
+            yield  # type: ignore[unreachable] # pragma: no cover
+
+        impl = make_wrapper_impl(no_yield)
+        with pytest.raises(RuntimeError, match="did not yield"):
+            impl.setup_and_get_completion_hook("myhook", {})
+
+    def test_second_yield_raises(self) -> None:
+        def two_yields() -> Generator[None, object, None]:
+            yield
+            yield
+
+        impl = make_wrapper_impl(two_yields)
+        completion = impl.setup_and_get_completion_hook("myhook", {})
+        result, exception = completion("x", None)
+        assert result == "x"
+        assert isinstance(exception, RuntimeError)
+        assert "has second yield" in str(exception)
+
+    def test_old_style_hookwrapper_receives_result_object(self) -> None:
+        seen: list[object] = []
+
+        def old_style(arg: object) -> Generator[None, object, None]:
+            outcome = yield
+            seen.append(outcome)
+            outcome.force_result(f"forced: {arg}")  # type: ignore[attr-defined]
+
+        impl = make_wrapper_impl(old_style, hookwrapper=True)
+        completion = impl.setup_and_get_completion_hook("myhook", {"arg": "a"})
+        result, exception = completion("orig", None)
+        assert result == "forced: a"
+        assert exception is None
+        assert seen and seen[0].__class__.__name__ == "Result"
+
+
+class TestRegistrationCreatesSubclasses:
+    def test_registered_impl_types(self) -> None:
+        class Spec:
+            @hookspec
+            def myhook(self, arg: object) -> None:
+                pass
+
+        class Plugin:
+            @hookimpl
+            def myhook(self, arg: object) -> object:
+                return arg
+
+            @hookimpl(wrapper=True)
+            def myhook_wrapper(self, arg: object) -> Generator[None, object, object]:
+                return (yield)
+
+        pm = PluginManager("example")
+        pm.add_hookspecs(Spec)
+        pm.register(Plugin())
+        impls = {type(impl).__name__ for impl in pm.hook.myhook.get_hookimpls()}
+        assert impls == {"NormalImpl"}
+        wrapper_impls = pm.hook.myhook_wrapper.get_hookimpls()
+        assert {type(impl).__name__ for impl in wrapper_impls} == {"WrapperImpl"}


### PR DESCRIPTION
<!-- stack-links -->
**Review PR — step 4 of 7.**

This PR targets the previous step's branch, so its diff is *only* this step's change. Review happens here. The corresponding upstream PR, which is the one that actually merges, is pytest-dev/pluggy#707.

Merges happen upstream one step at a time, bottom-up. When step 4 lands upstream, this PR is closed and the rest of the stack is rebased onto the new `main`.

| Step | Branch | Review (downstream) | Merge (upstream) |
| --- | --- | --- | --- |
| 1 | `refactor/split-hook-modules` | RonnyPfannschmidt/pluggy#6 | pytest-dev/pluggy#703 |
| 2 | `refactor/configuration-objects` | RonnyPfannschmidt/pluggy#5 | pytest-dev/pluggy#704 |
| 3 | `refactor/markers-attach-config` | RonnyPfannschmidt/pluggy#7 | pytest-dev/pluggy#706 |
| 4 | `refactor/hookimpl-wrapper-types` | RonnyPfannschmidt/pluggy#8 | pytest-dev/pluggy#707 **←** |
| 5 | `refactor/hookcaller-and-execution` | RonnyPfannschmidt/pluggy#9 | pytest-dev/pluggy#708 |
| 6 | `refactor/project-spec` | RonnyPfannschmidt/pluggy#10 | pytest-dev/pluggy#709 |
| 7 | `refactor/async-submitter` | RonnyPfannschmidt/pluggy#11 | pytest-dev/pluggy#710 |
<!-- /stack-links -->

Chain step 04 of the internal-refactoring series (design/04-hookimpl-wrapper-types.md).

HookImpl becomes a base class holding hookimpl_config; NormalImpl / WrapperImpl validate their configuration; HookimplConfiguration.create_hookimpl() picks the subclass; WrapperImpl.setup_and_get_completion_hook() exposes wrapper setup/teardown as a runtime-checkable CompletionHook.

Stacked on the step-03 chain PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a typed HookImpl hierarchy with NormalImpl and WrapperImpl, add a CompletionHook-based wrapper setup/teardown API, and update configuration, registration, and public exports to construct and expose the appropriate implementation types.

New Features:
- Introduce NormalImpl and WrapperImpl subclasses of HookImpl to distinguish normal and wrapper hook implementations.
- Add a runtime-checkable CompletionHook protocol and WrapperImpl.setup_and_get_completion_hook API to expose wrapper setup/teardown as a completion callback.

Enhancements:
- Refactor HookImpl to store HookimplConfiguration as hookimpl_config, add a deprecated opts alias, and move argument binding logic into _get_call_args with shared error handling.
- Add HookimplConfiguration.create_hookimpl factory to construct the appropriate HookImpl subclass based on configuration and use it in plugin registration and extra hook calls.
- Export NormalImpl, WrapperImpl, and CompletionHook from the public pluggy API and adjust HookImpl repr to show the concrete subclass name.

Documentation:
- Update API reference to include the new HookImpl subclasses and CompletionHook protocol.

Tests:
- Add test_implementation.py covering HookImpl subclass creation, argument binding, completion hook behavior for new and old-style wrappers, and plugin registration producing the correct impl types.
