### PR TITLE
refactor(caller): Protocol HookCaller, split callers, CompletionHook multicall

### DIFF
--- a/changelog/708.feature.rst
+++ b/changelog/708.feature.rst
@@ -1,0 +1,12 @@
+:class:`pluggy.HookCaller` is now a runtime-checkable
+:class:`~typing.Protocol` implemented by the new concrete callers
+:class:`pluggy.NormalHookCaller` (split normal/wrapper implementation
+lists), :class:`pluggy.HistoricHookCaller` (call memorization and replay,
+no wrappers) and :class:`pluggy.SubsetHookCaller`.
+``isinstance(caller, HookCaller)`` keeps working for all of them.
+
+The hook execution engine now runs a dual-sequence multicall: wrappers own
+their setup/teardown through ``CompletionHook`` callbacks which run LIFO
+after the normal implementations, removing all wrapper flag branching from
+the hot loop. Hook call monitoring callbacks still receive a single
+combined implementation list.

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -29,6 +29,17 @@ API Reference
     :members:
     :special-members: __call__
 
+.. autoclass:: pluggy.NormalHookCaller()
+    :members:
+    :special-members: __call__
+
+.. autoclass:: pluggy.HistoricHookCaller()
+    :members:
+    :special-members: __call__
+
+.. autoclass:: pluggy.SubsetHookCaller()
+    :members:
+
 .. autoclass:: pluggy.HookCallError()
     :show-inheritance:
     :members:

--- a/src/pluggy/__init__.py
+++ b/src/pluggy/__init__.py
@@ -1,4 +1,5 @@
 __all__ = [
+    "HistoricHookCaller",
     "HookCallError",
     "HookCaller",
     "HookImpl",
@@ -9,23 +10,28 @@ __all__ = [
     "HookspecConfiguration",
     "HookspecMarker",
     "HookspecOpts",
+    "NormalHookCaller",
     "NormalImpl",
     "PluggyTeardownRaisedWarning",
     "PluggyWarning",
     "PluginManager",
     "PluginValidationError",
     "Result",
+    "SubsetHookCaller",
     "WrapperImpl",
     "__version__",
 ]
 from ._config import HookimplConfiguration
 from ._config import HookspecConfiguration
+from ._hooks import HistoricHookCaller
 from ._hooks import HookCaller
 from ._hooks import HookImpl
 from ._hooks import HookimplMarker
 from ._hooks import HookRelay
 from ._hooks import HookspecMarker
+from ._hooks import NormalHookCaller
 from ._hooks import NormalImpl
+from ._hooks import SubsetHookCaller
 from ._hooks import WrapperImpl
 from ._manager import PluginManager
 from ._manager import PluginValidationError

--- a/src/pluggy/_caller.py
+++ b/src/pluggy/_caller.py
@@ -6,27 +6,123 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from collections.abc import Mapping
+from collections.abc import MutableSequence
 from collections.abc import Sequence
 from collections.abc import Set as AbstractSet
 from typing import Any
+from typing import cast
 from typing import Final
 from typing import final
+from typing import Protocol
+from typing import runtime_checkable
 from typing import TYPE_CHECKING
 from typing import TypeAlias
-import warnings
+from typing import TypeVar
 
 from ._config import HookimplConfiguration
+from ._config import hookspec_config_from_mapping
 from ._config import HookspecConfiguration
 from ._decorators import _Namespace
 from ._decorators import HookSpec
 from ._implementation import _Plugin
 from ._implementation import HookImpl
+from ._implementation import NormalImpl
+from ._implementation import WrapperImpl
 
 
 _HookExec: TypeAlias = Callable[
-    [str, Sequence[HookImpl], Mapping[str, object], bool],
-    object | list[object],
+    [str, Sequence[NormalImpl], Sequence[WrapperImpl], Mapping[str, object], bool],
+    "object | list[object]",
 ]
+
+_T_HookImpl = TypeVar("_T_HookImpl", bound=HookImpl)
+
+
+def _insert_hookimpl_into_list(
+    hookimpl: _T_HookImpl, target_list: MutableSequence[_T_HookImpl]
+) -> None:
+    """Insert a hookimpl into the target list maintaining proper ordering.
+
+    The ordering is: [trylast, normal, tryfirst].
+    """
+    if hookimpl.trylast:
+        target_list.insert(0, hookimpl)
+    elif hookimpl.tryfirst:
+        target_list.append(hookimpl)
+    else:
+        # find last non-tryfirst method
+        i = len(target_list) - 1
+        while i >= 0 and target_list[i].tryfirst:
+            i -= 1
+        target_list.insert(i + 1, hookimpl)
+
+
+def _coerce_spec_config(
+    spec_config: HookspecConfiguration | Mapping[str, Any],
+) -> HookspecConfiguration:
+    """Accept a configuration object or a legacy mapping (pytest shim)."""
+    if isinstance(spec_config, HookspecConfiguration):
+        return spec_config
+    return hookspec_config_from_mapping(spec_config)
+
+
+@runtime_checkable
+class HookCaller(Protocol):
+    """Protocol defining the interface for hook callers.
+
+    .. versionchanged:: 1.7
+        ``HookCaller`` is now a :class:`~typing.Protocol` (runtime checkable).
+        The concrete implementations are :class:`NormalHookCaller`,
+        :class:`HistoricHookCaller` and ``SubsetHookCaller``.
+    """
+
+    @property
+    def name(self) -> str:
+        """Name of the hook getting called."""
+        ...
+
+    @property
+    def spec(self) -> HookSpec | None:
+        """The hook specification, if any."""
+        ...
+
+    def has_spec(self) -> bool:
+        """Whether this caller has a hook specification."""
+        ...
+
+    def is_historic(self) -> bool:
+        """Whether this caller is :ref:`historic <historic>`."""
+        ...
+
+    def get_hookimpls(self) -> list[HookImpl]:
+        """Get all registered hook implementations for this hook."""
+        ...
+
+    def set_specification(
+        self,
+        specmodule_or_class: _Namespace,
+        spec_config: HookspecConfiguration | Mapping[str, Any],
+    ) -> None:
+        """Set the hook specification."""
+        ...
+
+    def __call__(self, **kwargs: object) -> Any:
+        """Call the hook with given kwargs."""
+        ...
+
+    def call_historic(
+        self,
+        result_callback: Callable[[Any], None] | None = None,
+        kwargs: Mapping[str, object] | None = None,
+    ) -> None:
+        """Call the hook historically."""
+        ...
+
+    def call_extra(
+        self, methods: Sequence[Callable[..., object]], kwargs: Mapping[str, object]
+    ) -> Any:
+        """Call the hook with additional methods."""
+        ...
 
 
 @final
@@ -41,7 +137,7 @@ class HookRelay:
 
     if TYPE_CHECKING:
 
-        def __getattr__(self, name: str) -> HookCaller: ...
+        def __getattr__(self, name: str) -> NormalHookCaller | HistoricHookCaller: ...
 
 
 # Historical name (pluggy<=1.2), kept for backward compatibility.
@@ -53,13 +149,13 @@ _CallHistory: TypeAlias = list[
 ]
 
 
-class HookCaller:
+class NormalHookCaller:
     """A caller of all registered implementations of a hook specification."""
 
     __slots__ = (
-        "_call_history",
         "_hookexec",
-        "_hookimpls",
+        "_normal_hookimpls",
+        "_wrapper_hookimpls",
         "name",
         "spec",
     )
@@ -69,26 +165,22 @@ class HookCaller:
         name: str,
         hook_execute: _HookExec,
         specmodule_or_class: _Namespace | None = None,
-        spec_opts: HookspecConfiguration | None = None,
+        spec_config: HookspecConfiguration | None = None,
     ) -> None:
         """:meta private:"""
         #: Name of the hook getting called.
         self.name: Final = name
         self._hookexec: Final = hook_execute
-        # The hookimpls list. The caller iterates it *in reverse*. Format:
-        # 1. trylast nonwrappers
-        # 2. nonwrappers
-        # 3. tryfirst nonwrappers
-        # 4. trylast wrappers
-        # 5. wrappers
-        # 6. tryfirst wrappers
-        self._hookimpls: Final[list[HookImpl]] = []
-        self._call_history: _CallHistory | None = None
+        # Split hook implementations into two lists for simpler management:
+        # Normal hooks: [trylast, normal, tryfirst]
+        # Wrapper hooks: [trylast, normal, tryfirst]
+        self._normal_hookimpls: Final[list[NormalImpl]] = []
+        self._wrapper_hookimpls: Final[list[WrapperImpl]] = []
         # TODO: Document, or make private.
         self.spec: HookSpec | None = None
         if specmodule_or_class is not None:
-            assert spec_opts is not None
-            self.set_specification(specmodule_or_class, spec_opts)
+            assert spec_config is not None
+            self.set_specification(specmodule_or_class, spec_config)
 
     # TODO: Document, or make private.
     def has_spec(self) -> bool:
@@ -98,77 +190,60 @@ class HookCaller:
     def set_specification(
         self,
         specmodule_or_class: _Namespace,
-        spec_opts: HookspecConfiguration,
+        spec_config: HookspecConfiguration | Mapping[str, Any],
     ) -> None:
         if self.spec is not None:
             raise ValueError(
                 f"Hook {self.spec.name!r} is already registered "
                 f"within namespace {self.spec.namespace}"
             )
-        self.spec = HookSpec(specmodule_or_class, self.name, spec_opts)
-        if spec_opts.historic:
-            self._call_history = []
+        config = _coerce_spec_config(spec_config)
+        if config.historic:
+            raise ValueError(
+                f"NormalHookCaller cannot handle historic hooks. "
+                f"Use HistoricHookCaller for {self.name!r}"
+            )
+        self.spec = HookSpec(specmodule_or_class, self.name, config)
 
     def is_historic(self) -> bool:
         """Whether this caller is :ref:`historic <historic>`."""
-        return self._call_history is not None
+        return False
 
     def _remove_plugin(self, plugin: _Plugin) -> None:
         """Remove all hook implementations registered by the given plugin."""
-        remaining = [impl for impl in self._hookimpls if impl.plugin != plugin]
-        if len(remaining) == len(self._hookimpls):
+        remaining_normal = [i for i in self._normal_hookimpls if i.plugin != plugin]
+        remaining_wrapper = [i for i in self._wrapper_hookimpls if i.plugin != plugin]
+        if len(remaining_normal) == len(self._normal_hookimpls) and len(
+            remaining_wrapper
+        ) == len(self._wrapper_hookimpls):
             raise ValueError(f"plugin {plugin!r} not found")
-        self._hookimpls[:] = remaining
+        self._normal_hookimpls[:] = remaining_normal
+        self._wrapper_hookimpls[:] = remaining_wrapper
 
     def get_hookimpls(self) -> list[HookImpl]:
-        """Get all registered hook implementations for this hook."""
-        return self._hookimpls.copy()
+        """Get all registered hook implementations for this hook.
+
+        Normal implementations come first, then wrappers (matching the
+        historical combined-list ordering).
+        """
+        return [*self._normal_hookimpls, *self._wrapper_hookimpls]
 
     def _add_hookimpl(self, hookimpl: HookImpl) -> None:
         """Add an implementation to the callback chain."""
-        for i, method in enumerate(self._hookimpls):
-            if method.hookwrapper or method.wrapper:
-                splitpoint = i
-                break
+        if isinstance(hookimpl, WrapperImpl):
+            _insert_hookimpl_into_list(hookimpl, self._wrapper_hookimpls)
         else:
-            splitpoint = len(self._hookimpls)
-        if hookimpl.hookwrapper or hookimpl.wrapper:
-            start, end = splitpoint, len(self._hookimpls)
-        else:
-            start, end = 0, splitpoint
-
-        if hookimpl.trylast:
-            self._hookimpls.insert(start, hookimpl)
-        elif hookimpl.tryfirst:
-            self._hookimpls.insert(end, hookimpl)
-        else:
-            # find last non-tryfirst method
-            i = end - 1
-            while i >= start and self._hookimpls[i].tryfirst:
-                i -= 1
-            self._hookimpls.insert(i + 1, hookimpl)
+            assert isinstance(hookimpl, NormalImpl), (
+                "normal hook implementations must be NormalImpl instances"
+            )
+            _insert_hookimpl_into_list(hookimpl, self._normal_hookimpls)
 
     def __repr__(self) -> str:
-        return f"<HookCaller {self.name!r}>"
+        return f"<NormalHookCaller {self.name!r}>"
 
     def _verify_all_args_are_provided(self, kwargs: Mapping[str, object]) -> None:
-        # This is written to avoid expensive operations when not needed.
         if self.spec:
-            for argname in self.spec.argnames:
-                if argname not in kwargs:
-                    notincall = ", ".join(
-                        repr(argname)
-                        for argname in self.spec.argnames
-                        # Avoid self.spec.argnames - kwargs.keys()
-                        # it doesn't preserve order.
-                        if argname not in kwargs
-                    )
-                    warnings.warn(
-                        f"Argument(s) {notincall} which are declared in the hookspec "
-                        "cannot be found in this hook call",
-                        stacklevel=2,
-                    )
-                    break
+            self.spec.verify_all_args_are_provided(kwargs)
 
     def __call__(self, **kwargs: object) -> Any:
         """Call the hook.
@@ -179,13 +254,140 @@ class HookCaller:
         Returns the result(s) of calling all registered plugins, see
         :ref:`calling`.
         """
-        assert not self.is_historic(), (
-            "Cannot directly call a historic hook - use call_historic instead."
-        )
         self._verify_all_args_are_provided(kwargs)
         firstresult = self.spec.config.firstresult if self.spec else False
         # Copy because plugins may register other plugins during iteration (#438).
-        return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
+        return self._hookexec(
+            self.name,
+            self._normal_hookimpls.copy(),
+            self._wrapper_hookimpls.copy(),
+            kwargs,
+            firstresult,
+        )
+
+    def call_historic(
+        self,
+        result_callback: Callable[[Any], None] | None = None,
+        kwargs: Mapping[str, object] | None = None,
+    ) -> None:
+        """Historic calls are only supported by historic hooks."""
+        raise AssertionError(
+            f"Hook {self.name!r} is not historic - cannot call call_historic"
+        )
+
+    def call_extra(
+        self, methods: Sequence[Callable[..., object]], kwargs: Mapping[str, object]
+    ) -> Any:
+        """Call the hook with some additional temporarily participating
+        methods using the specified ``kwargs`` as call parameters, see
+        :ref:`call_extra`."""
+        self._verify_all_args_are_provided(kwargs)
+        config = HookimplConfiguration()
+        normal_hookimpls = self._normal_hookimpls.copy()
+        for method in methods:
+            hookimpl = config.create_hookimpl(None, "<temp>", method)
+            # call_extra only supports normal implementations.
+            assert isinstance(hookimpl, NormalImpl)
+            _insert_hookimpl_into_list(hookimpl, normal_hookimpls)
+        firstresult = self.spec.config.firstresult if self.spec else False
+        return self._hookexec(
+            self.name,
+            normal_hookimpls,
+            self._wrapper_hookimpls.copy(),
+            kwargs,
+            firstresult,
+        )
+
+    def _maybe_apply_history(self, method: HookImpl) -> None:
+        """Nothing to do - normal hooks have no call history."""
+
+
+# Historical name (pluggy<=1.2), kept for backward compatibility.
+_HookCaller = NormalHookCaller
+
+
+class HistoricHookCaller:
+    """A caller for historic hook specifications that memorizes and replays
+    calls.
+
+    Historic hooks memorize every call and replay them on plugins registered
+    after the call was made. Historic hooks do not support wrappers.
+    """
+
+    __slots__ = (
+        "_call_history",
+        "_hookexec",
+        "_hookimpls",
+        "name",
+        "spec",
+    )
+
+    spec: HookSpec
+
+    def __init__(
+        self,
+        name: str,
+        hook_execute: _HookExec,
+        specmodule_or_class: _Namespace,
+        spec_config: HookspecConfiguration,
+    ) -> None:
+        """:meta private:"""
+        assert spec_config.historic, "HistoricHookCaller requires historic=True"
+        #: Name of the hook getting called.
+        self.name: Final = name
+        self._hookexec: Final = hook_execute
+        # The hookimpls list for historic hooks (no wrappers supported).
+        self._hookimpls: Final[list[NormalImpl]] = []
+        self._call_history: Final[_CallHistory] = []
+        # TODO: Document, or make private.
+        self.spec = HookSpec(specmodule_or_class, name, spec_config)
+
+    def has_spec(self) -> bool:
+        return True
+
+    def set_specification(
+        self,
+        specmodule_or_class: _Namespace,
+        spec_config: HookspecConfiguration | Mapping[str, Any],
+    ) -> None:
+        """Historic hooks cannot have their specification changed."""
+        raise ValueError(
+            f"Hook {self.spec.name!r} is already registered "
+            f"within namespace {self.spec.namespace}"
+        )
+
+    def is_historic(self) -> bool:
+        """Whether this caller is :ref:`historic <historic>`."""
+        return True
+
+    def _remove_plugin(self, plugin: _Plugin) -> None:
+        remaining = [impl for impl in self._hookimpls if impl.plugin != plugin]
+        if len(remaining) == len(self._hookimpls):
+            raise ValueError(f"plugin {plugin!r} not found")
+        self._hookimpls[:] = remaining
+
+    def get_hookimpls(self) -> list[HookImpl]:
+        """Get all registered hook implementations for this hook."""
+        return list(self._hookimpls)
+
+    def _add_hookimpl(self, hookimpl: HookImpl) -> None:
+        """Add an implementation to the callback chain."""
+        assert isinstance(hookimpl, NormalImpl), (
+            "historic hooks do not support wrappers"
+        )
+        _insert_hookimpl_into_list(hookimpl, self._hookimpls)
+
+    def __repr__(self) -> str:
+        return f"<HistoricHookCaller {self.name!r}>"
+
+    def __call__(self, **kwargs: object) -> Any:
+        """Historic hooks cannot be called directly.
+
+        Use :meth:`call_historic` instead.
+        """
+        raise AssertionError(
+            "Cannot directly call a historic hook - use call_historic instead."
+        )
 
     def call_historic(
         self,
@@ -200,14 +402,133 @@ class HookCaller:
             If provided, will be called for each non-``None`` result obtained
             from a hook implementation.
         """
-        assert self._call_history is not None
         kwargs = kwargs or {}
-        self._verify_all_args_are_provided(kwargs)
+        self.spec.verify_all_args_are_provided(kwargs)
         self._call_history.append((kwargs, result_callback))
         # Historizing hooks don't return results.
         # Remember firstresult isn't compatible with historic.
         # Copy because plugins may register other plugins during iteration (#438).
-        res = self._hookexec(self.name, self._hookimpls.copy(), kwargs, False)
+        res = self._hookexec(self.name, self._hookimpls.copy(), [], kwargs, False)
+        if result_callback is None:
+            return
+        if isinstance(res, list):
+            for x in res:
+                result_callback(x)
+
+    def call_extra(
+        self, methods: Sequence[Callable[..., object]], kwargs: Mapping[str, object]
+    ) -> Any:
+        """Historic hooks do not support call_extra."""
+        raise AssertionError(
+            "Cannot directly call a historic hook - use call_historic instead."
+        )
+
+    def _maybe_apply_history(self, method: HookImpl) -> None:
+        """Apply call history to a new hookimpl."""
+        assert isinstance(method, NormalImpl)
+        for kwargs, result_callback in self._call_history:
+            res = self._hookexec(self.name, [method], [], kwargs, False)
+            if res and result_callback is not None:
+                # XXX: remember firstresult isn't compat with historic
+                assert isinstance(res, list)
+                result_callback(res[0])
+
+
+class SubsetHookCaller:
+    """A proxy to another hook caller which manages calls to all registered
+    plugins except the ones from remove_plugins."""
+
+    # `subset_hook_caller` used to be implemented by creating a full-fledged
+    # HookCaller, copying all hookimpls from the original. This had problems
+    # with memory leaks (#346) and historic calls (#347), which make a proxy
+    # approach better.
+
+    __slots__ = (
+        "_orig",
+        "_remove_plugins",
+    )
+
+    def __init__(
+        self,
+        orig: NormalHookCaller | HistoricHookCaller,
+        remove_plugins: AbstractSet[_Plugin],
+    ) -> None:
+        """:meta private:"""
+        self._orig: Final = orig
+        self._remove_plugins: Final = remove_plugins
+
+    @property
+    def name(self) -> str:
+        return self._orig.name
+
+    @property
+    def spec(self) -> HookSpec | None:
+        return self._orig.spec
+
+    def has_spec(self) -> bool:
+        return self._orig.has_spec()
+
+    def is_historic(self) -> bool:
+        return self._orig.is_historic()
+
+    def _get_filtered(self, hookimpls: Sequence[_T_HookImpl]) -> list[_T_HookImpl]:
+        """Filter out hook implementations from removed plugins."""
+        return [impl for impl in hookimpls if impl.plugin not in self._remove_plugins]
+
+    def get_hookimpls(self) -> list[HookImpl]:
+        """Get filtered hook implementations for this hook."""
+        return self._get_filtered(self._orig.get_hookimpls())
+
+    def set_specification(
+        self,
+        specmodule_or_class: _Namespace,
+        spec_config: HookspecConfiguration | Mapping[str, Any],
+    ) -> None:
+        """SubsetHookCaller is a read-only proxy - specs cannot be set."""
+        raise RuntimeError(
+            f"Cannot set specification on SubsetHookCaller {self.name!r} - "
+            "it is a read-only proxy to another hook caller"
+        )
+
+    def __call__(self, **kwargs: object) -> Any:
+        """Call the hook with filtered implementations."""
+        if self.is_historic():
+            raise AssertionError(
+                "Cannot directly call a historic hook - use call_historic instead."
+            )
+        orig = self._orig
+        assert isinstance(orig, NormalHookCaller)
+        if orig.spec:
+            orig.spec.verify_all_args_are_provided(kwargs)
+        firstresult = orig.spec.config.firstresult if orig.spec else False
+        return orig._hookexec(
+            self.name,
+            self._get_filtered(orig._normal_hookimpls),
+            self._get_filtered(orig._wrapper_hookimpls),
+            kwargs,
+            firstresult,
+        )
+
+    def call_historic(
+        self,
+        result_callback: Callable[[Any], None] | None = None,
+        kwargs: Mapping[str, object] | None = None,
+    ) -> None:
+        """Call the hook with given ``kwargs`` for all registered plugins and
+        for all plugins which will be registered afterwards, see
+        :ref:`historic`.
+        """
+        orig = self._orig
+        assert isinstance(orig, HistoricHookCaller), (
+            f"Hook {self.name!r} is not historic - cannot call call_historic"
+        )
+        kwargs = kwargs or {}
+        orig.spec.verify_all_args_are_provided(kwargs)
+        # History is shared with the original caller.
+        orig._call_history.append((kwargs, result_callback))
+        res = orig._hookexec(
+            self.name, self._get_filtered(orig._hookimpls), [], kwargs, False
+        )
         if result_callback is None:
             return
         if isinstance(res, list):
@@ -220,83 +541,41 @@ class HookCaller:
         """Call the hook with some additional temporarily participating
         methods using the specified ``kwargs`` as call parameters, see
         :ref:`call_extra`."""
-        assert not self.is_historic(), (
-            "Cannot directly call a historic hook - use call_historic instead."
-        )
-        self._verify_all_args_are_provided(kwargs)
+        orig = self._orig
+        if self.is_historic():
+            raise AssertionError(
+                "Cannot directly call a historic hook - use call_historic instead."
+            )
+        assert isinstance(orig, NormalHookCaller)
+        if orig.spec:
+            orig.spec.verify_all_args_are_provided(kwargs)
         config = HookimplConfiguration()
-        hookimpls = self._hookimpls.copy()
+        normal_impls = self._get_filtered(orig._normal_hookimpls)
         for method in methods:
             hookimpl = config.create_hookimpl(None, "<temp>", method)
-            # Find last non-tryfirst nonwrapper method.
-            i = len(hookimpls) - 1
-            while i >= 0 and (
-                # Skip wrappers.
-                (hookimpls[i].hookwrapper or hookimpls[i].wrapper)
-                # Skip tryfirst nonwrappers.
-                or hookimpls[i].tryfirst
-            ):
-                i -= 1
-            hookimpls.insert(i + 1, hookimpl)
-        firstresult = self.spec.config.firstresult if self.spec else False
-        return self._hookexec(self.name, hookimpls, kwargs, firstresult)
-
-    def _maybe_apply_history(self, method: HookImpl) -> None:
-        """Apply call history to a new hookimpl if it is marked as historic."""
-        if self.is_historic():
-            assert self._call_history is not None
-            for kwargs, result_callback in self._call_history:
-                res = self._hookexec(self.name, [method], kwargs, False)
-                if res and result_callback is not None:
-                    # XXX: remember firstresult isn't compat with historic
-                    assert isinstance(res, list)
-                    result_callback(res[0])
-
-
-# Historical name (pluggy<=1.2), kept for backward compatibility.
-_HookCaller = HookCaller
-
-
-class _SubsetHookCaller(HookCaller):
-    """A proxy to another HookCaller which manages calls to all registered
-    plugins except the ones from remove_plugins."""
-
-    # This class is unusual: in inhertits from `HookCaller` so all of
-    # the *code* runs in the class, but it delegates all underlying *data*
-    # to the original HookCaller.
-    # `subset_hook_caller` used to be implemented by creating a full-fledged
-    # HookCaller, copying all hookimpls from the original. This had problems
-    # with memory leaks (#346) and historic calls (#347), which make a proxy
-    # approach better.
-    # An alternative implementation is to use a `_getattr__`/`__getattribute__`
-    # proxy, however that adds more overhead and is more tricky to implement.
-
-    __slots__ = (
-        "_orig",
-        "_remove_plugins",
-    )
-
-    def __init__(self, orig: HookCaller, remove_plugins: AbstractSet[_Plugin]) -> None:
-        self._orig = orig
-        self._remove_plugins = remove_plugins
-        self.name = orig.name  # type: ignore[misc]
-        self._hookexec = orig._hookexec  # type: ignore[misc]
-
-    @property  # type: ignore[misc]
-    def _hookimpls(self) -> list[HookImpl]:
-        return [
-            impl
-            for impl in self._orig._hookimpls
-            if impl.plugin not in self._remove_plugins
-        ]
-
-    @property
-    def spec(self) -> HookSpec | None:  # type: ignore[override]
-        return self._orig.spec
-
-    @property
-    def _call_history(self) -> _CallHistory | None:  # type: ignore[override]
-        return self._orig._call_history
+            assert isinstance(hookimpl, NormalImpl)
+            _insert_hookimpl_into_list(hookimpl, normal_impls)
+        firstresult = orig.spec.config.firstresult if orig.spec else False
+        return orig._hookexec(
+            self.name,
+            normal_impls,
+            self._get_filtered(orig._wrapper_hookimpls),
+            kwargs,
+            firstresult,
+        )
 
     def __repr__(self) -> str:
-        return f"<_SubsetHookCaller {self.name!r}>"
+        return f"<SubsetHookCaller {self.name!r}>"
+
+
+# Historical name, kept for backward compatibility.
+_SubsetHookCaller = SubsetHookCaller
+
+
+if TYPE_CHECKING:
+    # Verify the concrete callers satisfy the HookCaller protocol.
+    _: list[HookCaller] = [
+        cast(NormalHookCaller, None),
+        cast(HistoricHookCaller, None),
+        cast(SubsetHookCaller, None),
+    ]

--- a/src/pluggy/_decorators.py
+++ b/src/pluggy/_decorators.py
@@ -360,3 +360,22 @@ class HookSpec:
             Use :attr:`config` instead.
         """
         return self.config
+
+    def verify_all_args_are_provided(self, kwargs: Mapping[str, object]) -> None:
+        """Warn if a hook call does not provide all declared arguments."""
+        # This is written to avoid expensive operations when not needed.
+        for argname in self.argnames:
+            if argname not in kwargs:
+                notincall = ", ".join(
+                    repr(argname)
+                    for argname in self.argnames
+                    # Avoid self.argnames - kwargs.keys()
+                    # it doesn't preserve order.
+                    if argname not in kwargs
+                )
+                warnings.warn(
+                    f"Argument(s) {notincall} which are declared in the hookspec "
+                    "cannot be found in this hook call",
+                    stacklevel=3,
+                )
+                break

--- a/src/pluggy/_execution.py
+++ b/src/pluggy/_execution.py
@@ -13,7 +13,9 @@ from typing import TYPE_CHECKING
 from typing import TypeAlias
 import warnings
 
-from ._implementation import HookImpl
+from ._implementation import CompletionHook
+from ._implementation import NormalImpl
+from ._implementation import WrapperImpl
 from ._result import Result
 from ._warnings import PluggyTeardownRaisedWarning
 
@@ -24,7 +26,7 @@ Teardown: TypeAlias = Generator[None, object, object]
 
 
 def run_old_style_hookwrapper(
-    hook_impl: HookImpl, hook_name: str, args: Sequence[object]
+    hook_impl: WrapperImpl, hook_name: str, args: Sequence[object]
 ) -> Teardown:
     """
     backward compatibility wrapper to run a old style hookwrapper as a wrapper
@@ -67,7 +69,7 @@ def _raise_wrapfail(
 
 
 def _warn_teardown_exception(
-    hook_name: str, hook_impl: HookImpl, e: BaseException
+    hook_name: str, hook_impl: WrapperImpl, e: BaseException
 ) -> None:
     msg = (
         f"A plugin raised an exception during an old-style hookwrapper teardown.\n"
@@ -75,12 +77,13 @@ def _warn_teardown_exception(
         f"{type(e).__name__}: {e}\n"
         f"For more information see https://pluggy.readthedocs.io/en/stable/api_reference.html#pluggy.PluggyTeardownRaisedWarning"
     )
-    warnings.warn(PluggyTeardownRaisedWarning(msg), stacklevel=6)
+    warnings.warn(PluggyTeardownRaisedWarning(msg), stacklevel=7)
 
 
 def _multicall(
     hook_name: str,
-    hook_impls: Sequence[HookImpl],
+    normal_impls: Sequence[NormalImpl],
+    wrapper_impls: Sequence[WrapperImpl],
     caller_kwargs: Mapping[str, object],
     firstresult: bool,
 ) -> object | list[object]:
@@ -88,79 +91,48 @@ def _multicall(
     result(s).
 
     ``caller_kwargs`` comes from HookCaller.__call__().
+
+    Wrappers own their setup/teardown via
+    :meth:`~pluggy._implementation.WrapperImpl.setup_and_get_completion_hook`;
+    this function only orchestrates the phases:
+
+    1. Set up wrappers, collecting their completion hooks.
+    2. Run normal implementations.
+    3. Run completion hooks LIFO, each may replace ``(result, exception)``.
+    4. Raise or return.
     """
     __tracebackhide__ = True
     results: list[object] = []
-    exception = None
-    teardowns: list[Teardown] = []
-    try:  # run impl and wrapper setup functions in a loop
-        for hook_impl in reversed(hook_impls):
-            args = hook_impl._get_call_args(caller_kwargs)
+    exception: BaseException | None = None
+    completion_hooks: list[CompletionHook] = []
+    try:
+        # Set up all wrappers and collect their completion hooks.
+        for wrapper_impl in reversed(wrapper_impls):
+            completion_hooks.append(
+                wrapper_impl.setup_and_get_completion_hook(hook_name, caller_kwargs)
+            )
 
-            if hook_impl.hookwrapper:
-                function_gen = run_old_style_hookwrapper(hook_impl, hook_name, args)
-
-                next(function_gen)  # first yield
-                teardowns.append(function_gen)
-
-            elif hook_impl.wrapper:
-                res = hook_impl.function(*args)
-                # If this cast is not valid, a type error is raised below,
-                # which is the desired response.
-                if TYPE_CHECKING:
-                    function_gen = cast(Generator[None, object, object], res)
-                else:
-                    function_gen = res
-                try:
-                    next(function_gen)  # first yield
-                except StopIteration:
-                    _raise_wrapfail(function_gen, "did not yield")
-                teardowns.append(function_gen)
-            else:
-                res = hook_impl.function(*args)
-                if res is not None:
-                    results.append(res)
-                    if firstresult:  # halt further impl calls
-                        break
+        # Run normal implementations.
+        for normal_impl in reversed(normal_impls):
+            args = normal_impl._get_call_args(caller_kwargs)
+            res = normal_impl.function(*args)
+            if res is not None:
+                results.append(res)
+                if firstresult:  # halt further impl calls
+                    break
     except BaseException as exc:
         exception = exc
-    finally:
-        if firstresult:  # first result hooks return a single value
-            result = results[0] if results else None
-        else:
-            result = results
 
-        # run all wrapper post-yield blocks
-        for teardown in reversed(teardowns):
-            try:
-                if exception is not None:
-                    try:
-                        teardown.throw(exception)
-                    except RuntimeError as re:
-                        # StopIteration from generator causes RuntimeError
-                        # even for coroutine usage - see #544
-                        if (
-                            isinstance(exception, StopIteration)
-                            and re.__cause__ is exception
-                        ):
-                            teardown.close()
-                            continue
-                        else:
-                            raise
-                else:
-                    teardown.send(result)
-                # Following is unreachable for a well behaved hook wrapper.
-                # Try to force finalizers otherwise postponed till GC action.
-                # Note: close() may raise if generator handles GeneratorExit.
-                teardown.close()
-            except StopIteration as si:
-                result = si.value
-                exception = None
-                continue
-            except BaseException as e:
-                exception = e
-                continue
-            _raise_wrapfail(teardown, "has second yield")
+    result: object | list[object] | None
+    if firstresult:  # first result hooks return a single value
+        result = results[0] if results else None
+    else:
+        result = results
+
+    # Run completion hooks in reverse order (LIFO); each may replace the
+    # current (result, exception) outcome.
+    for completion_hook in reversed(completion_hooks):
+        result, exception = completion_hook(result, exception)
 
     if exception is not None:
         raise exception

--- a/src/pluggy/_hooks.py
+++ b/src/pluggy/_hooks.py
@@ -11,8 +11,11 @@ from ._caller import _HookCaller
 from ._caller import _HookExec
 from ._caller import _HookRelay
 from ._caller import _SubsetHookCaller
+from ._caller import HistoricHookCaller
 from ._caller import HookCaller
 from ._caller import HookRelay
+from ._caller import NormalHookCaller
+from ._caller import SubsetHookCaller
 from ._config import HookimplConfiguration
 from ._config import HookspecConfiguration
 from ._decorators import _Namespace
@@ -30,6 +33,7 @@ from ._implementation import WrapperImpl
 
 __all__ = [
     "CompletionHook",
+    "HistoricHookCaller",
     "HookCaller",
     "HookImpl",
     "HookRelay",
@@ -38,7 +42,9 @@ __all__ = [
     "HookimplMarker",
     "HookspecConfiguration",
     "HookspecMarker",
+    "NormalHookCaller",
     "NormalImpl",
+    "SubsetHookCaller",
     "WrapperImpl",
     "_HookCaller",
     "_HookExec",

--- a/src/pluggy/_manager.py
+++ b/src/pluggy/_manager.py
@@ -24,10 +24,14 @@ from ._config import HookspecConfiguration
 from ._hooks import _HookImplFunction
 from ._hooks import _Namespace
 from ._hooks import _Plugin
-from ._hooks import _SubsetHookCaller
+from ._hooks import HistoricHookCaller
 from ._hooks import HookCaller
 from ._hooks import HookImpl
 from ._hooks import HookRelay
+from ._hooks import NormalHookCaller
+from ._hooks import NormalImpl
+from ._hooks import SubsetHookCaller
+from ._hooks import WrapperImpl
 from ._pytest_compat import HookimplOpts
 from ._pytest_compat import HookspecOpts
 from ._result import Result
@@ -104,13 +108,16 @@ class PluginManager:
     def _hookexec(
         self,
         hook_name: str,
-        methods: Sequence[HookImpl],
-        kwargs: Mapping[str, object],
+        normal_impls: Sequence[NormalImpl],
+        wrapper_impls: Sequence[WrapperImpl],
+        caller_kwargs: Mapping[str, object],
         firstresult: bool,
     ) -> object | list[object]:
         # called from all hookcaller instances.
         # enable_tracing will set its own wrapping function at self._inner_hookexec
-        return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
+        return self._inner_hookexec(
+            hook_name, normal_impls, wrapper_impls, caller_kwargs, firstresult
+        )
 
     def register(self, plugin: _Plugin, name: str | None = None) -> str | None:
         """Register a plugin and return its name.
@@ -152,9 +159,11 @@ class PluginManager:
                 method: _HookImplFunction[object] = getattr(plugin, attr_name)
                 hookimpl = hookimpl_config.create_hookimpl(plugin, plugin_name, method)
                 hook_name = hookimpl_config.specname or attr_name
-                hook: HookCaller | None = getattr(self.hook, hook_name, None)
+                hook: NormalHookCaller | HistoricHookCaller | None = getattr(
+                    self.hook, hook_name, None
+                )
                 if hook is None:
-                    hook = HookCaller(hook_name, self._hookexec)
+                    hook = NormalHookCaller(hook_name, self._hookexec)
                     setattr(self.hook, hook_name, hook)
                 elif hook.has_spec():
                     self._verify_hook(hook, hookimpl)
@@ -241,6 +250,7 @@ class PluginManager:
         hookcallers = self.get_hookcallers(plugin)
         if hookcallers:
             for hookcaller in hookcallers:
+                assert isinstance(hookcaller, (NormalHookCaller, HistoricHookCaller))
                 hookcaller._remove_plugin(plugin)
 
         # if self._name2plugin[name] == None registration was blocked: ignore
@@ -279,10 +289,36 @@ class PluginManager:
         for name in dir(module_or_class):
             spec_config = self._discover_hookspec_configuration(module_or_class, name)
             if spec_config is not None:
-                hc: HookCaller | None = getattr(self.hook, name, None)
+                hc: NormalHookCaller | HistoricHookCaller | None = getattr(
+                    self.hook, name, None
+                )
                 if hc is None:
-                    hc = HookCaller(name, self._hookexec, module_or_class, spec_config)
+                    if spec_config.historic:
+                        hc = HistoricHookCaller(
+                            name, self._hookexec, module_or_class, spec_config
+                        )
+                    else:
+                        hc = NormalHookCaller(
+                            name, self._hookexec, module_or_class, spec_config
+                        )
                     setattr(self.hook, name, hc)
+                elif spec_config.historic and not hc.is_historic():
+                    # Plugins registered this hook before the historic spec was
+                    # known - hand the implementations over to a
+                    # HistoricHookCaller.
+                    assert isinstance(hc, NormalHookCaller)
+                    if hc.has_spec():
+                        # Let set_specification raise the usual error.
+                        hc.set_specification(module_or_class, spec_config)
+                        raise AssertionError("unreachable")  # pragma: no cover
+                    old_hookimpls = hc.get_hookimpls()
+                    historic_hc = HistoricHookCaller(
+                        name, self._hookexec, module_or_class, spec_config
+                    )
+                    setattr(self.hook, name, historic_hc)
+                    for hookimpl in old_hookimpls:
+                        self._verify_hook(historic_hc, hookimpl)
+                        historic_hc._add_hookimpl(hookimpl)
                 else:
                     # Plugins registered this hook without knowing the spec.
                     hc.set_specification(module_or_class, spec_config)
@@ -439,7 +475,7 @@ class PluginManager:
         for name in self.hook.__dict__:
             if name[0] == "_":
                 continue
-            hook: HookCaller = getattr(self.hook, name)
+            hook: NormalHookCaller | HistoricHookCaller = getattr(self.hook, name)
             if not hook.has_spec():
                 for hookimpl in hook.get_hookimpls():
                     if not hookimpl.optionalhook:
@@ -540,13 +576,19 @@ class PluginManager:
 
         def traced_hookexec(
             hook_name: str,
-            hook_impls: Sequence[HookImpl],
+            normal_impls: Sequence[NormalImpl],
+            wrapper_impls: Sequence[WrapperImpl],
             caller_kwargs: Mapping[str, object],
             firstresult: bool,
         ) -> object | list[object]:
+            # For backward compatibility of the before/after callback shapes,
+            # combine the split lists into one.
+            hook_impls: list[HookImpl] = [*normal_impls, *wrapper_impls]
             before(hook_name, hook_impls, caller_kwargs)
             outcome = Result.from_call(
-                lambda: oldcall(hook_name, hook_impls, caller_kwargs, firstresult)
+                lambda: oldcall(
+                    hook_name, normal_impls, wrapper_impls, caller_kwargs, firstresult
+                )
             )
             after(outcome, hook_name, hook_impls, caller_kwargs)
             return outcome.get_result()
@@ -589,10 +631,10 @@ class PluginManager:
         """Return a proxy :class:`~pluggy.HookCaller` instance for the named
         method which manages calls to all registered plugins except the ones
         from remove_plugins."""
-        orig: HookCaller = getattr(self.hook, name)
+        orig: NormalHookCaller | HistoricHookCaller = getattr(self.hook, name)
         plugins_to_remove = {plug for plug in remove_plugins if hasattr(plug, name)}
         if plugins_to_remove:
-            return _SubsetHookCaller(orig, plugins_to_remove)
+            return SubsetHookCaller(orig, plugins_to_remove)
         return orig
 
 

--- a/testing/benchmark.py
+++ b/testing/benchmark.py
@@ -11,8 +11,8 @@ import pytest
 from pluggy import HookimplMarker
 from pluggy import HookspecMarker
 from pluggy import PluginManager
+from pluggy import WrapperImpl
 from pluggy._callers import _multicall
-from pluggy._hooks import HookImpl
 from pluggy._hooks import varnames
 
 
@@ -104,13 +104,17 @@ def wrappers(request: Any) -> list[object]:
 def test_hook_and_wrappers_speed(benchmark, hooks, wrappers) -> None:
     def setup():
         hook_name = "foo"
-        hook_impls = []
+        normal_impls = []
+        wrapper_impls = []
         for method in hooks + wrappers:
-            f = HookImpl(None, "<temp>", method, method.example_impl)
-            hook_impls.append(f)
+            f = method.example_impl.create_hookimpl(None, "<temp>", method)
+            if isinstance(f, WrapperImpl):
+                wrapper_impls.append(f)
+            else:
+                normal_impls.append(f)
         caller_kwargs = {"arg1": 1, "arg2": 2, "arg3": 3}
         firstresult = False
-        return (hook_name, hook_impls, caller_kwargs, firstresult), {}
+        return (hook_name, normal_impls, wrapper_impls, caller_kwargs, firstresult), {}
 
     benchmark.pedantic(_multicall, setup=setup, rounds=10)
 

--- a/testing/test_hookcaller.py
+++ b/testing/test_hookcaller.py
@@ -5,11 +5,14 @@ from typing import TypeVar
 
 import pytest
 
+from pluggy import HistoricHookCaller
+from pluggy import HookCaller
 from pluggy import HookimplMarker
+from pluggy import HookspecConfiguration
 from pluggy import HookspecMarker
+from pluggy import NormalHookCaller
 from pluggy import PluginManager
 from pluggy import PluginValidationError
-from pluggy._hooks import HookCaller
 from pluggy._hooks import HookImpl
 
 
@@ -18,21 +21,23 @@ hookimpl = HookimplMarker("example")
 
 
 @pytest.fixture
-def hc(pm: PluginManager) -> HookCaller:
+def hc(pm: PluginManager) -> NormalHookCaller:
     class Hooks:
         @hookspec
         def he_method1(self, arg: object) -> None:
             pass
 
     pm.add_hookspecs(Hooks)
-    return pm.hook.he_method1
+    hc = pm.hook.he_method1
+    assert isinstance(hc, NormalHookCaller)
+    return hc
 
 
 FuncT = TypeVar("FuncT", bound=Callable[..., object])
 
 
 class AddMeth:
-    def __init__(self, hc: HookCaller) -> None:
+    def __init__(self, hc: NormalHookCaller) -> None:
         self.hc = hc
 
     def __call__(
@@ -49,16 +54,15 @@ class AddMeth:
                 hookwrapper=hookwrapper,
                 wrapper=wrapper,
             )(func)
-            self.hc._add_hookimpl(
-                HookImpl(None, "<temp>", func, func.example_impl),  # type: ignore[attr-defined]
-            )
+            config = func.example_impl  # type: ignore[attr-defined]
+            self.hc._add_hookimpl(config.create_hookimpl(None, "<temp>", func))
             return func
 
         return wrap
 
 
 @pytest.fixture
-def addmeth(hc: HookCaller) -> AddMeth:
+def addmeth(hc: NormalHookCaller) -> AddMeth:
     return AddMeth(hc)
 
 
@@ -66,7 +70,7 @@ def funcs(hookmethods: Sequence[HookImpl]) -> list[Callable[..., object]]:
     return [hookmethod.function for hookmethod in hookmethods]
 
 
-def test_adding_nonwrappers(hc: HookCaller, addmeth: AddMeth) -> None:
+def test_adding_nonwrappers(hc: NormalHookCaller, addmeth: AddMeth) -> None:
     @addmeth()
     def he_method1() -> None:
         pass
@@ -82,7 +86,7 @@ def test_adding_nonwrappers(hc: HookCaller, addmeth: AddMeth) -> None:
     assert funcs(hc.get_hookimpls()) == [he_method1, he_method2, he_method3]
 
 
-def test_adding_nonwrappers_trylast(hc: HookCaller, addmeth: AddMeth) -> None:
+def test_adding_nonwrappers_trylast(hc: NormalHookCaller, addmeth: AddMeth) -> None:
     @addmeth()
     def he_method1_middle() -> None:
         pass
@@ -98,7 +102,7 @@ def test_adding_nonwrappers_trylast(hc: HookCaller, addmeth: AddMeth) -> None:
     assert funcs(hc.get_hookimpls()) == [he_method1, he_method1_middle, he_method1_b]
 
 
-def test_adding_nonwrappers_trylast3(hc: HookCaller, addmeth: AddMeth) -> None:
+def test_adding_nonwrappers_trylast3(hc: NormalHookCaller, addmeth: AddMeth) -> None:
     @addmeth()
     def he_method1_a() -> None:
         pass
@@ -123,7 +127,7 @@ def test_adding_nonwrappers_trylast3(hc: HookCaller, addmeth: AddMeth) -> None:
     ]
 
 
-def test_adding_nonwrappers_trylast2(hc: HookCaller, addmeth: AddMeth) -> None:
+def test_adding_nonwrappers_trylast2(hc: NormalHookCaller, addmeth: AddMeth) -> None:
     @addmeth()
     def he_method1_middle() -> None:
         pass
@@ -139,7 +143,7 @@ def test_adding_nonwrappers_trylast2(hc: HookCaller, addmeth: AddMeth) -> None:
     assert funcs(hc.get_hookimpls()) == [he_method1, he_method1_middle, he_method1_b]
 
 
-def test_adding_nonwrappers_tryfirst(hc: HookCaller, addmeth: AddMeth) -> None:
+def test_adding_nonwrappers_tryfirst(hc: NormalHookCaller, addmeth: AddMeth) -> None:
     @addmeth(tryfirst=True)
     def he_method1() -> None:
         pass
@@ -155,7 +159,7 @@ def test_adding_nonwrappers_tryfirst(hc: HookCaller, addmeth: AddMeth) -> None:
     assert funcs(hc.get_hookimpls()) == [he_method1_middle, he_method1_b, he_method1]
 
 
-def test_adding_wrappers_ordering(hc: HookCaller, addmeth: AddMeth) -> None:
+def test_adding_wrappers_ordering(hc: NormalHookCaller, addmeth: AddMeth) -> None:
     @addmeth(hookwrapper=True)
     def he_method1():
         yield  # pragma: no cover
@@ -185,7 +189,9 @@ def test_adding_wrappers_ordering(hc: HookCaller, addmeth: AddMeth) -> None:
     ]
 
 
-def test_adding_wrappers_ordering_tryfirst(hc: HookCaller, addmeth: AddMeth) -> None:
+def test_adding_wrappers_ordering_tryfirst(
+    hc: NormalHookCaller, addmeth: AddMeth
+) -> None:
     @addmeth(hookwrapper=True, tryfirst=True)
     def he_method1():
         yield  # pragma: no cover
@@ -201,7 +207,7 @@ def test_adding_wrappers_ordering_tryfirst(hc: HookCaller, addmeth: AddMeth) -> 
     assert funcs(hc.get_hookimpls()) == [he_method2, he_method1, he_method3]
 
 
-def test_adding_wrappers_complex(hc: HookCaller, addmeth: AddMeth) -> None:
+def test_adding_wrappers_complex(hc: NormalHookCaller, addmeth: AddMeth) -> None:
     assert funcs(hc.get_hookimpls()) == []
 
     @addmeth(hookwrapper=True, trylast=True)
@@ -442,7 +448,7 @@ def test_hook_conflict(pm: PluginManager) -> None:
     )
 
 
-def test_call_extra_hook_order(hc: HookCaller, addmeth: AddMeth) -> None:
+def test_call_extra_hook_order(hc: NormalHookCaller, addmeth: AddMeth) -> None:
     """Ensure that call_extra is calling hooks in the right order."""
     order = []
 
@@ -513,7 +519,9 @@ def test_call_extra_hook_order(hc: HookCaller, addmeth: AddMeth) -> None:
     ]
 
 
-def test_remove_plugin_not_found_raises(hc: HookCaller, pm: PluginManager) -> None:
+def test_remove_plugin_not_found_raises(
+    hc: NormalHookCaller, pm: PluginManager
+) -> None:
     """_remove_plugin() raises ValueError for a plugin that never registered
     an implementation on this particular hook caller."""
 
@@ -533,3 +541,83 @@ def test_remove_plugin_not_found_raises(hc: HookCaller, pm: PluginManager) -> No
     # the failed removal must not have touched the existing registration
     assert len(hc.get_hookimpls()) == 1
     pm.unregister(plugin)
+
+
+def test_hookcaller_is_runtime_checkable_protocol(pm: PluginManager) -> None:
+    class Hooks:
+        @hookspec
+        def he_method1(self, arg: object) -> None:
+            pass
+
+        @hookspec(historic=True)
+        def he_history(self, arg: object) -> None:
+            pass
+
+    class Plugin:
+        @hookimpl
+        def he_method1(self, arg: object) -> object:
+            return arg
+
+    pm.add_hookspecs(Hooks)
+    pm.register(Plugin())
+
+    normal = pm.hook.he_method1
+    historic = pm.hook.he_history
+    subset = pm.subset_hook_caller("he_method1", [])
+
+    assert isinstance(normal, NormalHookCaller)
+    assert isinstance(historic, HistoricHookCaller)
+    for caller in (normal, historic, subset):
+        assert isinstance(caller, HookCaller)
+
+    assert not normal.is_historic()
+    assert historic.is_historic()
+
+
+def test_historic_spec_after_registration_hands_over(pm: PluginManager) -> None:
+    """Impls registered before a historic spec move to a HistoricHookCaller."""
+    out: list[object] = []
+
+    class Plugin:
+        @hookimpl
+        def he_history(self, arg: object) -> object:
+            out.append(arg)
+            return arg
+
+    pm.register(Plugin())
+    pre_spec_caller = pm.hook.he_history
+    assert isinstance(pre_spec_caller, NormalHookCaller)
+
+    class Hooks:
+        @hookspec(historic=True)
+        def he_history(self, arg: object) -> None:
+            pass
+
+    pm.add_hookspecs(Hooks)
+    hc = pm.hook.he_history
+    assert isinstance(hc, HistoricHookCaller)
+    assert len(hc.get_hookimpls()) == 1
+
+    hc.call_historic(kwargs={"arg": 1})
+    assert out == [1]
+
+
+def test_historic_rejects_direct_call_and_call_extra(pm: PluginManager) -> None:
+    class Hooks:
+        @hookspec(historic=True)
+        def he_history(self, arg: object) -> None:
+            pass
+
+    pm.add_hookspecs(Hooks)
+    hc = pm.hook.he_history
+    with pytest.raises(AssertionError, match="use call_historic"):
+        hc(arg=1)
+    with pytest.raises(AssertionError, match="use call_historic"):
+        hc.call_extra([], {"arg": 1})
+    with pytest.raises(ValueError, match="already registered"):
+        hc.set_specification(Hooks, HookspecConfiguration(historic=True))
+
+
+def test_normal_caller_rejects_call_historic(hc: NormalHookCaller) -> None:
+    with pytest.raises(AssertionError, match="not historic"):
+        hc.call_historic(kwargs={"arg": 1})

--- a/testing/test_multicall.py
+++ b/testing/test_multicall.py
@@ -7,8 +7,9 @@ import pytest
 from pluggy import HookCallError
 from pluggy import HookimplMarker
 from pluggy import HookspecMarker
+from pluggy import NormalImpl
+from pluggy import WrapperImpl
 from pluggy._callers import _multicall
-from pluggy._hooks import HookImpl
 
 
 hookspec = HookspecMarker("example")
@@ -20,12 +21,16 @@ def MC(
     kwargs: Mapping[str, object],
     firstresult: bool = False,
 ) -> object | list[object]:
-    caller = _multicall
-    hookfuncs = []
+    normal_impls: list[NormalImpl] = []
+    wrapper_impls: list[WrapperImpl] = []
     for method in methods:
-        f = HookImpl(None, "<temp>", method, method.example_impl)  # type: ignore[attr-defined]
-        hookfuncs.append(f)
-    return caller("foo", hookfuncs, kwargs, firstresult)
+        config = method.example_impl  # type: ignore[attr-defined]
+        f = config.create_hookimpl(None, "<temp>", method)
+        if isinstance(f, WrapperImpl):
+            wrapper_impls.append(f)
+        else:
+            normal_impls.append(f)
+    return _multicall("foo", normal_impls, wrapper_impls, kwargs, firstresult)
 
 
 def test_keyword_args() -> None:

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -494,7 +494,7 @@ def test_subset_hook_caller(pm: PluginManager) -> None:
     pm.hook.he_method1(arg=1)
     assert out == [10]
 
-    assert repr(hc) == "<_SubsetHookCaller 'he_method1'>"
+    assert repr(hc) == "<SubsetHookCaller 'he_method1'>"
 
 
 def test_get_hookimpls(pm: PluginManager) -> None:


### PR DESCRIPTION
<!-- stack-links -->
**Review PR — step 5 of 7.**

This PR targets the previous step's branch, so its diff is *only* this step's change. Review happens here. The corresponding upstream PR, which is the one that actually merges, is pytest-dev/pluggy#708.

Merges happen upstream one step at a time, bottom-up. When step 5 lands upstream, this PR is closed and the rest of the stack is rebased onto the new `main`.

| Step | Branch | Review (downstream) | Merge (upstream) |
| --- | --- | --- | --- |
| 1 | `refactor/split-hook-modules` | RonnyPfannschmidt/pluggy#6 | pytest-dev/pluggy#703 |
| 2 | `refactor/configuration-objects` | RonnyPfannschmidt/pluggy#5 | pytest-dev/pluggy#704 |
| 3 | `refactor/markers-attach-config` | RonnyPfannschmidt/pluggy#7 | pytest-dev/pluggy#706 |
| 4 | `refactor/hookimpl-wrapper-types` | RonnyPfannschmidt/pluggy#8 | pytest-dev/pluggy#707 |
| 5 | `refactor/hookcaller-and-execution` | RonnyPfannschmidt/pluggy#9 | pytest-dev/pluggy#708 **←** |
| 6 | `refactor/project-spec` | RonnyPfannschmidt/pluggy#10 | pytest-dev/pluggy#709 |
| 7 | `refactor/async-submitter` | RonnyPfannschmidt/pluggy#11 | pytest-dev/pluggy#710 |
<!-- /stack-links -->

Chain step 05 of the internal-refactoring series (design/05-hookcaller-and-execution.md).

HookCaller becomes a @runtime_checkable Protocol over NormalHookCaller (split normal/wrapper lists), HistoricHookCaller and SubsetHookCaller; _multicall is dual-sequence phase orchestration with LIFO CompletionHook teardown and no wrapper flag branching; historic specs arriving after impl registration hand over to a HistoricHookCaller; tracing keeps the combined-list callback shape.

Stacked on the step-04 chain PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refactor hook calling infrastructure to split normal and wrapper implementations, introduce protocol-based HookCaller variants, and update multicall execution and plugin manager to support historic hooks and subset callers while preserving tracing and public APIs.

New Features:
- Expose NormalHookCaller, HistoricHookCaller, and SubsetHookCaller as concrete hook caller types implementing a runtime-checkable HookCaller protocol.
- Support historic hook specifications via a dedicated HistoricHookCaller that records call history and replays it for late-registered plugins.
- Allow subset_hook_caller to proxy both normal and historic hook callers with filtered implementations.

Enhancements:
- Split hook implementations into separate normal and wrapper lists and adjust multicall orchestration to use completion hooks with LIFO teardown.
- Move hookspec argument verification into HookSpec and reuse it across caller implementations.
- Update tracing, benchmarks, and tests to work with the new hook caller and multicall shapes while keeping callback signatures compatible.

Documentation:
- Add a changelog entry describing the HookCaller refactor and historic hook handling changes.

Tests:
- Extend and adjust hookcaller and multicall tests to cover the new NormalHookCaller, HistoricHookCaller, SubsetHookCaller, and historic hand-over behavior.
